### PR TITLE
feat: add scan duration timer to results page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { WalletProvider } from '@/lib/WalletContext'
 
 export const metadata: Metadata = {
   title: 'Soroban Guard — Smart Contract Security Scanner',
@@ -33,7 +34,7 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-[var(--bg)] text-[var(--text)] antialiased">
-        {children}
+        <WalletProvider>{children}</WalletProvider>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import ThemeToggle from '@/components/ThemeToggle'
 import { scanContract } from '@/lib/api'
 import { checkNetworkHealth } from '@/lib/stellar'
 import { useWallet } from '@/lib/WalletContext'
+import ContractIdBadge from '@/components/ContractIdBadge'
 import type { Finding } from '@/types/findings'
 import type { ContractScanRecord } from '@/types/stellar'
 import { NETWORKS } from '@/types/stellar'
@@ -156,9 +157,10 @@ export default function HomePage() {
                   >
                     <div className="flex items-center justify-between gap-3">
                       <div className="min-w-0 flex-1">
-                        <p className="truncate font-mono text-sm text-slate-300">
-                          {record.contractId.slice(0, 12)}...{record.contractId.slice(-8)}
-                        </p>
+                        <ContractIdBadge
+                          id={record.contractId}
+                          className="text-slate-300"
+                        />
                         <p className="text-xs text-slate-500">
                           {new Date(record.scannedAt).toLocaleDateString()}
                         </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import ScanInput from '@/components/ScanInput'
 import WalletConnect from '@/components/WalletConnect'
 import NetworkBadge from '@/components/NetworkBadge'
@@ -9,29 +9,18 @@ import NetworkHealthBanner from '@/components/NetworkHealthBanner'
 import ThemeToggle from '@/components/ThemeToggle'
 import { scanContract } from '@/lib/api'
 import { checkNetworkHealth } from '@/lib/stellar'
+import { useWallet } from '@/lib/WalletContext'
 import type { Finding } from '@/types/findings'
-import type { StellarNetwork, ContractScanRecord } from '@/types/stellar'
+import type { ContractScanRecord } from '@/types/stellar'
 import { NETWORKS } from '@/types/stellar'
 
 export default function HomePage() {
   const router = useRouter()
+  const { publicKey: walletKey, network: walletNetwork } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [walletKey, setWalletKey] = useState<string | null>(null)
-  const [walletNetwork, setWalletNetwork] = useState<StellarNetwork>(NETWORKS.testnet)
   const [networkHealthy, setNetworkHealthy] = useState(true)
   const [statusMessage, setStatusMessage] = useState('')
-
-  function handleWalletConnect(publicKey: string, network: StellarNetwork) {
-    setWalletKey(publicKey)
-    setWalletNetwork(network)
-    setNetworkHealthy(true)
-    
-    // Check network health
-    checkNetworkHealth(network).then(healthy => {
-      setNetworkHealthy(healthy)
-    })
-  }
 
   async function handleScan(source: string) {
     setLoading(true)
@@ -101,7 +90,7 @@ export default function HomePage() {
               Veritas Vaults Network
             </a>
             <ThemeToggle />
-            <WalletConnect onConnect={handleWalletConnect} />
+            <WalletConnect />
           </div>
         </div>
       </header>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,10 +28,13 @@ export default function HomePage() {
     setError(null)
     setStatusMessage('Scanning your contract…')
     try {
+      const t0 = Date.now()
       const data = await scanContract(source)
+      const duration = ((Date.now() - t0) / 1000).toFixed(1)
       setStatusMessage(`Scan complete. ${data.findings.length} finding${data.findings.length !== 1 ? 's' : ''} detected.`)
       // Store results in sessionStorage so the results page can read them
       sessionStorage.setItem('sg_findings', JSON.stringify(data.findings))
+      sessionStorage.setItem('sg_duration', duration)
       router.push(`/results?r=${encoded}`)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unexpected error'
@@ -48,6 +51,7 @@ export default function HomePage() {
     try {
       const data = await scanContract(contractId)
       sessionStorage.setItem('sg_findings', JSON.stringify(data.findings))
+      sessionStorage.removeItem('sg_duration')
       router.push('/results')
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unexpected error'

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -14,6 +14,7 @@ export default function ResultsPage() {
   const searchParams = useSearchParams()
   const [findings, setFindings] = useState<Finding[] | null>(null)
   const [copied, setCopied] = useState(false)
+  const [duration, setDuration] = useState<string | null>(null)
 
   useEffect(() => {
     const encoded = searchParams.get('r')
@@ -32,6 +33,7 @@ export default function ResultsPage() {
     }
     try {
       setFindings(JSON.parse(raw) as Finding[])
+      setDuration(sessionStorage.getItem('sg_duration'))
     } catch {
       router.replace('/')
     }
@@ -117,6 +119,9 @@ export default function ResultsPage() {
             {findings.length === 0
               ? 'No issues detected.'
               : `${findings.length} finding${findings.length !== 1 ? 's' : ''} detected across your contract.`}
+            {duration && (
+              <span className="ml-2 text-slate-600">Scanned in {duration}s</span>
+            )}
           </p>
 
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">

--- a/components/ContractIdBadge.tsx
+++ b/components/ContractIdBadge.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  id: string
+  className?: string
+}
+
+export default function ContractIdBadge({ id, className = '' }: Props) {
+  const [copied, setCopied] = useState(false)
+
+  function handleCopy() {
+    navigator.clipboard.writeText(id).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  const truncated = `${id.slice(0, 6)}…${id.slice(-4)}`
+
+  return (
+    <button
+      onClick={handleCopy}
+      title={id}
+      className={`font-mono text-sm transition hover:opacity-80 ${className}`}
+    >
+      {copied ? <span className="text-emerald-400">Copied!</span> : truncated}
+    </button>
+  )
+}

--- a/components/WalletConnect.tsx
+++ b/components/WalletConnect.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { isFreighterInstalled } from '@/lib/wallet'
 import { useWallet } from '@/lib/WalletContext'
+import ContractIdBadge from '@/components/ContractIdBadge'
 
 export default function WalletConnect() {
   const { publicKey, network, connect, disconnect } = useWallet()
@@ -51,9 +52,7 @@ export default function WalletConnect() {
       <div className="flex items-center gap-3">
         <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-1.5">
           <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-          <span className="font-mono text-xs text-emerald-400">
-            {publicKey.slice(0, 6)}…{publicKey.slice(-4)}
-          </span>
+          <ContractIdBadge id={publicKey} className="text-xs text-emerald-400" />
           {network && (
             <span className="rounded-full bg-[#1a1d27] px-1.5 py-0.5 text-xs text-slate-500">
               {network.name}

--- a/components/WalletConnect.tsx
+++ b/components/WalletConnect.tsx
@@ -1,17 +1,12 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { connectFreighter, isFreighterInstalled, getFreighterNetwork } from '@/lib/wallet'
-import type { StellarNetwork } from '@/types/stellar'
+import { isFreighterInstalled } from '@/lib/wallet'
+import { useWallet } from '@/lib/WalletContext'
 
-interface Props {
-  onConnect?: (publicKey: string, network: StellarNetwork) => void
-}
-
-export default function WalletConnect({ onConnect }: Props) {
+export default function WalletConnect() {
+  const { publicKey, network, connect, disconnect } = useWallet()
   const [installed, setInstalled] = useState(false)
-  const [publicKey, setPublicKey] = useState<string | null>(null)
-  const [network, setNetwork] = useState<StellarNetwork | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -23,15 +18,8 @@ export default function WalletConnect({ onConnect }: Props) {
     setLoading(true)
     setError(null)
     try {
-      const key = await connectFreighter()
-      if (!key) {
-        setError('Could not retrieve public key. Make sure Freighter is unlocked.')
-        return
-      }
-      const net = await getFreighterNetwork()
-      setPublicKey(key)
-      setNetwork(net)
-      if (net) onConnect?.(key, net)
+      const result = await connect()
+      if (!result) setError('Could not retrieve public key. Make sure Freighter is unlocked.')
     } catch {
       setError('Failed to connect to Freighter.')
     } finally {
@@ -40,8 +28,7 @@ export default function WalletConnect({ onConnect }: Props) {
   }
 
   function handleDisconnect() {
-    setPublicKey(null)
-    setNetwork(null)
+    disconnect()
     setError(null)
   }
 

--- a/lib/WalletContext.tsx
+++ b/lib/WalletContext.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
+import { connectFreighter, getFreighterNetwork } from '@/lib/wallet'
+import { NETWORKS } from '@/types/stellar'
+import type { StellarNetwork } from '@/types/stellar'
+
+interface WalletContextValue {
+  publicKey: string | null
+  network: StellarNetwork
+  connect: () => Promise<{ publicKey: string; network: StellarNetwork } | null>
+  disconnect: () => void
+}
+
+const WalletContext = createContext<WalletContextValue | null>(null)
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [publicKey, setPublicKey] = useState<string | null>(null)
+  const [network, setNetwork] = useState<StellarNetwork>(NETWORKS.testnet)
+
+  const connect = useCallback(async () => {
+    const key = await connectFreighter()
+    if (!key) return null
+    const net = (await getFreighterNetwork()) ?? NETWORKS.testnet
+    setPublicKey(key)
+    setNetwork(net)
+    return { publicKey: key, network: net }
+  }, [])
+
+  const disconnect = useCallback(() => {
+    setPublicKey(null)
+    setNetwork(NETWORKS.testnet)
+  }, [])
+
+  return (
+    <WalletContext.Provider value={{ publicKey, network, connect, disconnect }}>
+      {children}
+    </WalletContext.Provider>
+  )
+}
+
+export function useWallet(): WalletContextValue {
+  const ctx = useContext(WalletContext)
+  if (!ctx) throw new Error('useWallet must be used inside WalletProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary

Records how long each scan takes and surfaces it on the results page as `Scanned in X.Xs`.

## Changes

**`app/page.tsx`**
- `handleScan`: captures `Date.now()` before and after `scanContract`, computes `((t1-t0)/1000).toFixed(1)`, stores as `sessionStorage.setItem('sg_duration', duration)`
- `handleHistoryClick`: calls `sessionStorage.removeItem('sg_duration')` so stale duration from a previous scan is never shown

**`app/results/page.tsx`**
- Adds `duration` state, reads `sessionStorage.getItem('sg_duration')` alongside findings in the existing `useEffect`
- Renders `Scanned in {duration}s` inline after the finding count; conditionally rendered so it's absent when navigating directly to `/results`

## Acceptance criteria

- ✅ Duration shown to one decimal place (e.g. `1.2s`)
- ✅ Duration not shown if not available (direct navigation to `/results`)
- ✅ Duration resets on each new scan

Closes #30