### PR TITLE
docs: add SECURITY.md with responsible disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| `main`  | ✅ Yes    |
+
+Only the latest code on the `main` branch receives security fixes.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Please report them via one of the following:
+
+- **GitHub Private Advisory** — [Report a vulnerability](../../security/advisories/new) (preferred)
+- **Email** — `security@veritas-vaults.network`
+
+Include as much detail as possible: steps to reproduce, affected component, and potential impact.
+
+## Response Timeline
+
+| Milestone | Target |
+|-----------|--------|
+| Acknowledgement | Within 48 hours |
+| Status update | Within 7 days |
+| Patch / fix released | Within 14 days of confirmation |
+
+We will coordinate a disclosure date with you once a fix is ready.
+
+## Out of Scope
+
+The following are **not** considered in-scope vulnerabilities:
+
+- Bugs in third-party dependencies (report upstream)
+- Issues in the Stellar network or Soroban protocol itself
+- Freighter wallet internals
+- Findings from automated scanners without a working proof-of-concept
+- Social engineering or phishing attacks
+
+## Disclosure Policy
+
+We follow [responsible disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure). Please give us reasonable time to address the issue before any public disclosure.


### PR DESCRIPTION
Closes #32

## What
Adds `SECURITY.md` at the repo root to provide a clear responsible disclosure policy.

## Included
- Supported versions table (main branch only)
- Two reporting channels: GitHub Private Advisory (preferred) + email
- Response timeline: 48h acknowledgement, 14-day patch target
- Out-of-scope items: third-party deps, Stellar/Soroban network, Freighter internals, scanner-only findings
- Coordinated disclosure statement

Follows the [GitHub recommended format](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).