### PR TITLE
feat: add OpenGraph and Twitter card meta tags to results page

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -1,0 +1,207 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import type { Finding, Severity } from '@/types/findings'
+import { decodeFindings } from '@/lib/share'
+import FindingsTable from '@/components/FindingsTable'
+import EmptyState from '@/components/EmptyState'
+import SeverityBadge from '@/components/SeverityBadge'
+import ThemeToggle from '@/components/ThemeToggle'
+
+export default function ResultsPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [findings, setFindings] = useState<Finding[] | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    const encoded = searchParams.get('r')
+    if (encoded) {
+      const decoded = decodeFindings(encoded)
+      if (decoded.length > 0) {
+        setFindings(decoded)
+        return
+      }
+    }
+
+    const raw = sessionStorage.getItem('sg_findings')
+    if (!raw) {
+      router.replace('/')
+      return
+    }
+    try {
+      setFindings(JSON.parse(raw) as Finding[])
+    } catch {
+      router.replace('/')
+    }
+  }, [router, searchParams])
+
+  function handleScanAnother() {
+    sessionStorage.removeItem('sg_findings')
+    router.push('/')
+  }
+
+  function handleShare() {
+    const url = window.location.href
+    navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  if (findings === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <svg className="spinner h-8 w-8 text-indigo-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+          <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
+        </svg>
+      </div>
+    )
+  }
+
+  const counts: Record<Severity, number> = { High: 0, Medium: 0, Low: 0 }
+  for (const f of findings) counts[f.severity]++
+
+  const canCopy = typeof navigator !== 'undefined' && navigator.clipboard
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* Nav */}
+      <header className="border-b border-[var(--border)] bg-[var(--bg)]/80 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+          <button
+            onClick={handleScanAnother}
+            className="flex items-center gap-2 text-sm text-slate-400 transition hover:text-white"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            Soroban Guard
+          </button>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleScanAnother}
+              className="rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-indigo-500"
+            >
+              Scan another contract
+            </button>
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6">
+        {/* Summary bar */}
+        <div className="mb-8">
+          <div className="mb-4 flex items-center justify-between">
+            <h1 className="text-2xl font-bold text-white">Scan Results</h1>
+            <div className="relative">
+              <button
+                onClick={handleCopyJson}
+                disabled={!canCopy}
+                title={canCopy ? 'Copy findings as JSON' : 'Clipboard API unavailable'}
+                className="rounded-lg p-2 text-slate-400 transition hover:bg-[#1a1d27] hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              </button>
+              {copied && (
+                <div className="absolute right-0 top-full mt-2 whitespace-nowrap rounded-lg bg-green-600 px-3 py-1 text-xs text-white">
+                  Copied!
+                </div>
+              )}
+            </div>
+          </div>
+          <p className="mb-6 text-sm text-slate-500">
+            {findings.length === 0
+              ? 'No issues detected.'
+              : `${findings.length} finding${findings.length !== 1 ? 's' : ''} detected across your contract.`}
+          </p>
+
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <SummaryCard
+              label="Total Findings"
+              value={findings.length}
+              color="text-white"
+              bg="bg-[#1a1d27]"
+            />
+            <SummaryCard
+              label="High"
+              value={counts.High}
+              color="text-red-400"
+              bg="bg-red-500/5"
+              border="border-red-500/20"
+            />
+            <SummaryCard
+              label="Medium"
+              value={counts.Medium}
+              color="text-amber-400"
+              bg="bg-amber-500/5"
+              border="border-amber-500/20"
+            />
+            <SummaryCard
+              label="Low"
+              value={counts.Low}
+              color="text-sky-400"
+              bg="bg-sky-500/5"
+              border="border-sky-500/20"
+            />
+          </div>
+        </div>
+
+        {/* Findings or empty state */}
+        {findings.length === 0 ? (
+          <EmptyState onScanAnother={handleScanAnother} />
+        ) : (
+          <div>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-slate-400">
+                Findings — click a row to expand details
+              </h2>
+              <div className="flex gap-2">
+                {(['High', 'Medium', 'Low'] as Severity[]).map(s =>
+                  counts[s] > 0 ? (
+                    <SeverityBadge key={s} severity={s} size="sm" />
+                  ) : null,
+                )}
+              </div>
+            </div>
+            {/* Sort: High → Medium → Low */}
+            <FindingsTable
+              findings={[...findings].sort((a, b) => {
+                const order: Record<Severity, number> = { High: 0, Medium: 1, Low: 2 }
+                return order[a.severity] - order[b.severity]
+              })}
+            />
+          </div>
+        )}
+      </main>
+
+      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
+        Soroban Guard · Veritas Vaults Network
+      </footer>
+    </div>
+  )
+}
+
+function SummaryCard({
+  label,
+  value,
+  color,
+  bg,
+  border = 'border-[var(--border)]',
+}: {
+  label: string
+  value: number
+  color: string
+  bg: string
+  border?: string
+}) {
+  return (
+    <div className={`rounded-xl border ${border} ${bg} px-5 py-4`}>
+      <p className="mb-1 text-xs text-slate-500">{label}</p>
+      <p className={`text-3xl font-bold ${color}`}>{value}</p>
+    </div>
+  )
+}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,207 +1,45 @@
-'use client'
-
-import { useEffect, useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import type { Metadata } from 'next'
 import type { Finding, Severity } from '@/types/findings'
 import { decodeFindings } from '@/lib/share'
-import FindingsTable from '@/components/FindingsTable'
-import EmptyState from '@/components/EmptyState'
-import SeverityBadge from '@/components/SeverityBadge'
-import ThemeToggle from '@/components/ThemeToggle'
+import ResultsClient from './ResultsClient'
 
-export default function ResultsPage() {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const [findings, setFindings] = useState<Finding[] | null>(null)
-  const [copied, setCopied] = useState(false)
+interface Props {
+  searchParams: { r?: string }
+}
 
-  useEffect(() => {
-    const encoded = searchParams.get('r')
-    if (encoded) {
-      const decoded = decodeFindings(encoded)
-      if (decoded.length > 0) {
-        setFindings(decoded)
-        return
-      }
+export function generateMetadata({ searchParams }: Props): Metadata {
+  const r = searchParams.r
+  if (!r) {
+    return {
+      title: 'Soroban Guard — Scan Results',
+      openGraph: { title: 'Soroban Guard — Scan Results' },
+      twitter: { card: 'summary' },
     }
-
-    const raw = sessionStorage.getItem('sg_findings')
-    if (!raw) {
-      router.replace('/')
-      return
-    }
-    try {
-      setFindings(JSON.parse(raw) as Finding[])
-    } catch {
-      router.replace('/')
-    }
-  }, [router, searchParams])
-
-  function handleScanAnother() {
-    sessionStorage.removeItem('sg_findings')
-    router.push('/')
   }
 
-  function handleShare() {
-    const url = window.location.href
-    navigator.clipboard.writeText(url)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
-
-  if (findings === null) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <svg className="spinner h-8 w-8 text-indigo-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-          <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
-        </svg>
-      </div>
-    )
+  const findings = decodeFindings(r)
+  if (findings.length === 0) {
+    return {
+      title: 'Soroban Guard — Scan Results',
+      openGraph: { title: 'Soroban Guard — Scan Results' },
+      twitter: { card: 'summary' },
+    }
   }
 
   const counts: Record<Severity, number> = { High: 0, Medium: 0, Low: 0 }
   for (const f of findings) counts[f.severity]++
 
-  const canCopy = typeof navigator !== 'undefined' && navigator.clipboard
+  const title = `Soroban Guard — ${findings.length} finding${findings.length !== 1 ? 's' : ''} detected`
+  const description = `High: ${counts.High} · Medium: ${counts.Medium} · Low: ${counts.Low}`
 
-  return (
-    <div className="flex min-h-screen flex-col">
-      {/* Nav */}
-      <header className="border-b border-[var(--border)] bg-[var(--bg)]/80 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
-          <button
-            onClick={handleScanAnother}
-            className="flex items-center gap-2 text-sm text-slate-400 transition hover:text-white"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-            </svg>
-            Soroban Guard
-          </button>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handleScanAnother}
-              className="rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-indigo-500"
-            >
-              Scan another contract
-            </button>
-            <ThemeToggle />
-          </div>
-        </div>
-      </header>
-
-      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6">
-        {/* Summary bar */}
-        <div className="mb-8">
-          <div className="mb-4 flex items-center justify-between">
-            <h1 className="text-2xl font-bold text-white">Scan Results</h1>
-            <div className="relative">
-              <button
-                onClick={handleCopyJson}
-                disabled={!canCopy}
-                title={canCopy ? 'Copy findings as JSON' : 'Clipboard API unavailable'}
-                className="rounded-lg p-2 text-slate-400 transition hover:bg-[#1a1d27] hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
-              </button>
-              {copied && (
-                <div className="absolute right-0 top-full mt-2 whitespace-nowrap rounded-lg bg-green-600 px-3 py-1 text-xs text-white">
-                  Copied!
-                </div>
-              )}
-            </div>
-          </div>
-          <p className="mb-6 text-sm text-slate-500">
-            {findings.length === 0
-              ? 'No issues detected.'
-              : `${findings.length} finding${findings.length !== 1 ? 's' : ''} detected across your contract.`}
-          </p>
-
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <SummaryCard
-              label="Total Findings"
-              value={findings.length}
-              color="text-white"
-              bg="bg-[#1a1d27]"
-            />
-            <SummaryCard
-              label="High"
-              value={counts.High}
-              color="text-red-400"
-              bg="bg-red-500/5"
-              border="border-red-500/20"
-            />
-            <SummaryCard
-              label="Medium"
-              value={counts.Medium}
-              color="text-amber-400"
-              bg="bg-amber-500/5"
-              border="border-amber-500/20"
-            />
-            <SummaryCard
-              label="Low"
-              value={counts.Low}
-              color="text-sky-400"
-              bg="bg-sky-500/5"
-              border="border-sky-500/20"
-            />
-          </div>
-        </div>
-
-        {/* Findings or empty state */}
-        {findings.length === 0 ? (
-          <EmptyState onScanAnother={handleScanAnother} />
-        ) : (
-          <div>
-            <div className="mb-3 flex items-center justify-between">
-              <h2 className="text-sm font-semibold text-slate-400">
-                Findings — click a row to expand details
-              </h2>
-              <div className="flex gap-2">
-                {(['High', 'Medium', 'Low'] as Severity[]).map(s =>
-                  counts[s] > 0 ? (
-                    <SeverityBadge key={s} severity={s} size="sm" />
-                  ) : null,
-                )}
-              </div>
-            </div>
-            {/* Sort: High → Medium → Low */}
-            <FindingsTable
-              findings={[...findings].sort((a, b) => {
-                const order: Record<Severity, number> = { High: 0, Medium: 1, Low: 2 }
-                return order[a.severity] - order[b.severity]
-              })}
-            />
-          </div>
-        )}
-      </main>
-
-      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
-        Soroban Guard · Veritas Vaults Network
-      </footer>
-    </div>
-  )
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+    twitter: { card: 'summary', title, description },
+  }
 }
 
-function SummaryCard({
-  label,
-  value,
-  color,
-  bg,
-  border = 'border-[var(--border)]',
-}: {
-  label: string
-  value: number
-  color: string
-  bg: string
-  border?: string
-}) {
-  return (
-    <div className={`rounded-xl border ${border} ${bg} px-5 py-4`}>
-      <p className="mb-1 text-xs text-slate-500">{label}</p>
-      <p className={`text-3xl font-bold ${color}`}>{value}</p>
-    </div>
-  )
+export default function ResultsPage({ searchParams }: Props) {
+  return <ResultsClient />
 }


### PR DESCRIPTION
Closes #33

## What
Splits `app/results/page.tsx` into a server wrapper + client component so Next.js can run `generateMetadata` at the server level without hydration issues.

## Changes
- `app/results/ResultsClient.tsx` — existing client component (renamed, no logic changes)
- `app/results/page.tsx` — new server component that exports `generateMetadata` and renders `<ResultsClient />`

## Metadata behaviour
| Condition | og:title | og:description |
|-----------|----------|----------------|
| No `?r=` param | `Soroban Guard — Scan Results` | _(none)_ |
| `?r=` present, valid | `Soroban Guard — N findings detected` | `High: X · Medium: Y · Low: Z` |
| `twitter:card` | `summary` in all cases | |