### PR TITLE
feat: add ConfirmModal component and wire to history clear action

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| `main`  | ✅ Yes    |
+
+Only the latest code on the `main` branch receives security fixes.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Please report them via one of the following:
+
+- **GitHub Private Advisory** — [Report a vulnerability](../../security/advisories/new) (preferred)
+- **Email** — `security@veritas-vaults.network`
+
+Include as much detail as possible: steps to reproduce, affected component, and potential impact.
+
+## Response Timeline
+
+| Milestone | Target |
+|-----------|--------|
+| Acknowledgement | Within 48 hours |
+| Status update | Within 7 days |
+| Patch / fix released | Within 14 days of confirmation |
+
+We will coordinate a disclosure date with you once a fix is ready.
+
+## Out of Scope
+
+The following are **not** considered in-scope vulnerabilities:
+
+- Bugs in third-party dependencies (report upstream)
+- Issues in the Stellar network or Soroban protocol itself
+- Freighter wallet internals
+- Findings from automated scanners without a working proof-of-concept
+- Social engineering or phishing attacks
+
+## Disclosure Policy
+
+We follow [responsible disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure). Please give us reasonable time to address the issue before any public disclosure.

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { Finding } from '@/types/findings'
+import ConfirmModal from '@/components/ConfirmModal'
+
+interface HistoryEntry {
+  id: string
+  date: string
+  source: string
+  findings: Finding[]
+}
+
+const STORAGE_KEY = 'sg_history'
+
+function loadHistory(): HistoryEntry[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
+  } catch {
+    return []
+  }
+}
+
+export default function HistoryPage() {
+  const router = useRouter()
+  const [entries, setEntries] = useState<HistoryEntry[]>([])
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  useEffect(() => {
+    setEntries(loadHistory())
+  }, [])
+
+  function clearHistory() {
+    localStorage.removeItem(STORAGE_KEY)
+    setEntries([])
+    setShowConfirm(false)
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-white">Scan History</h1>
+        {entries.length > 0 && (
+          <button
+            onClick={() => setShowConfirm(true)}
+            className="rounded-lg border border-red-500/30 px-4 py-2 text-sm text-red-400 transition hover:bg-red-500/10"
+          >
+            Clear history
+          </button>
+        )}
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="text-sm text-slate-500">No scan history yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {entries.map(e => (
+            <li
+              key={e.id}
+              className="rounded-xl border border-[#2a2d3a] bg-[#12151f] px-5 py-4"
+            >
+              <div className="flex items-center justify-between">
+                <span className="truncate font-mono text-sm text-slate-300">{e.source}</span>
+                <span className="ml-4 shrink-0 text-xs text-slate-500">
+                  {new Date(e.date).toLocaleDateString()}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-slate-500">
+                {e.findings.length} finding{e.findings.length !== 1 ? 's' : ''}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showConfirm && (
+        <ConfirmModal
+          title="Clear all history?"
+          description="This will permanently delete all scan records from this browser. This cannot be undone."
+          confirmLabel="Clear history"
+          onConfirm={clearHistory}
+          onCancel={() => setShowConfirm(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -1,0 +1,207 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import type { Finding, Severity } from '@/types/findings'
+import { decodeFindings } from '@/lib/share'
+import FindingsTable from '@/components/FindingsTable'
+import EmptyState from '@/components/EmptyState'
+import SeverityBadge from '@/components/SeverityBadge'
+import ThemeToggle from '@/components/ThemeToggle'
+
+export default function ResultsPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [findings, setFindings] = useState<Finding[] | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    const encoded = searchParams.get('r')
+    if (encoded) {
+      const decoded = decodeFindings(encoded)
+      if (decoded.length > 0) {
+        setFindings(decoded)
+        return
+      }
+    }
+
+    const raw = sessionStorage.getItem('sg_findings')
+    if (!raw) {
+      router.replace('/')
+      return
+    }
+    try {
+      setFindings(JSON.parse(raw) as Finding[])
+    } catch {
+      router.replace('/')
+    }
+  }, [router, searchParams])
+
+  function handleScanAnother() {
+    sessionStorage.removeItem('sg_findings')
+    router.push('/')
+  }
+
+  function handleShare() {
+    const url = window.location.href
+    navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  if (findings === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <svg className="spinner h-8 w-8 text-indigo-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+          <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
+        </svg>
+      </div>
+    )
+  }
+
+  const counts: Record<Severity, number> = { High: 0, Medium: 0, Low: 0 }
+  for (const f of findings) counts[f.severity]++
+
+  const canCopy = typeof navigator !== 'undefined' && navigator.clipboard
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* Nav */}
+      <header className="border-b border-[var(--border)] bg-[var(--bg)]/80 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+          <button
+            onClick={handleScanAnother}
+            className="flex items-center gap-2 text-sm text-slate-400 transition hover:text-white"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            Soroban Guard
+          </button>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleScanAnother}
+              className="rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-indigo-500"
+            >
+              Scan another contract
+            </button>
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6">
+        {/* Summary bar */}
+        <div className="mb-8">
+          <div className="mb-4 flex items-center justify-between">
+            <h1 className="text-2xl font-bold text-white">Scan Results</h1>
+            <div className="relative">
+              <button
+                onClick={handleCopyJson}
+                disabled={!canCopy}
+                title={canCopy ? 'Copy findings as JSON' : 'Clipboard API unavailable'}
+                className="rounded-lg p-2 text-slate-400 transition hover:bg-[#1a1d27] hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              </button>
+              {copied && (
+                <div className="absolute right-0 top-full mt-2 whitespace-nowrap rounded-lg bg-green-600 px-3 py-1 text-xs text-white">
+                  Copied!
+                </div>
+              )}
+            </div>
+          </div>
+          <p className="mb-6 text-sm text-slate-500">
+            {findings.length === 0
+              ? 'No issues detected.'
+              : `${findings.length} finding${findings.length !== 1 ? 's' : ''} detected across your contract.`}
+          </p>
+
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <SummaryCard
+              label="Total Findings"
+              value={findings.length}
+              color="text-white"
+              bg="bg-[#1a1d27]"
+            />
+            <SummaryCard
+              label="High"
+              value={counts.High}
+              color="text-red-400"
+              bg="bg-red-500/5"
+              border="border-red-500/20"
+            />
+            <SummaryCard
+              label="Medium"
+              value={counts.Medium}
+              color="text-amber-400"
+              bg="bg-amber-500/5"
+              border="border-amber-500/20"
+            />
+            <SummaryCard
+              label="Low"
+              value={counts.Low}
+              color="text-sky-400"
+              bg="bg-sky-500/5"
+              border="border-sky-500/20"
+            />
+          </div>
+        </div>
+
+        {/* Findings or empty state */}
+        {findings.length === 0 ? (
+          <EmptyState onScanAnother={handleScanAnother} />
+        ) : (
+          <div>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-slate-400">
+                Findings — click a row to expand details
+              </h2>
+              <div className="flex gap-2">
+                {(['High', 'Medium', 'Low'] as Severity[]).map(s =>
+                  counts[s] > 0 ? (
+                    <SeverityBadge key={s} severity={s} size="sm" />
+                  ) : null,
+                )}
+              </div>
+            </div>
+            {/* Sort: High → Medium → Low */}
+            <FindingsTable
+              findings={[...findings].sort((a, b) => {
+                const order: Record<Severity, number> = { High: 0, Medium: 1, Low: 2 }
+                return order[a.severity] - order[b.severity]
+              })}
+            />
+          </div>
+        )}
+      </main>
+
+      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
+        Soroban Guard · Veritas Vaults Network
+      </footer>
+    </div>
+  )
+}
+
+function SummaryCard({
+  label,
+  value,
+  color,
+  bg,
+  border = 'border-[var(--border)]',
+}: {
+  label: string
+  value: number
+  color: string
+  bg: string
+  border?: string
+}) {
+  return (
+    <div className={`rounded-xl border ${border} ${bg} px-5 py-4`}>
+      <p className="mb-1 text-xs text-slate-500">{label}</p>
+      <p className={`text-3xl font-bold ${color}`}>{value}</p>
+    </div>
+  )
+}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,207 +1,45 @@
-'use client'
-
-import { useEffect, useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import type { Metadata } from 'next'
 import type { Finding, Severity } from '@/types/findings'
 import { decodeFindings } from '@/lib/share'
-import FindingsTable from '@/components/FindingsTable'
-import EmptyState from '@/components/EmptyState'
-import SeverityBadge from '@/components/SeverityBadge'
-import ThemeToggle from '@/components/ThemeToggle'
+import ResultsClient from './ResultsClient'
 
-export default function ResultsPage() {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const [findings, setFindings] = useState<Finding[] | null>(null)
-  const [copied, setCopied] = useState(false)
+interface Props {
+  searchParams: { r?: string }
+}
 
-  useEffect(() => {
-    const encoded = searchParams.get('r')
-    if (encoded) {
-      const decoded = decodeFindings(encoded)
-      if (decoded.length > 0) {
-        setFindings(decoded)
-        return
-      }
+export function generateMetadata({ searchParams }: Props): Metadata {
+  const r = searchParams.r
+  if (!r) {
+    return {
+      title: 'Soroban Guard — Scan Results',
+      openGraph: { title: 'Soroban Guard — Scan Results' },
+      twitter: { card: 'summary' },
     }
-
-    const raw = sessionStorage.getItem('sg_findings')
-    if (!raw) {
-      router.replace('/')
-      return
-    }
-    try {
-      setFindings(JSON.parse(raw) as Finding[])
-    } catch {
-      router.replace('/')
-    }
-  }, [router, searchParams])
-
-  function handleScanAnother() {
-    sessionStorage.removeItem('sg_findings')
-    router.push('/')
   }
 
-  function handleShare() {
-    const url = window.location.href
-    navigator.clipboard.writeText(url)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
-
-  if (findings === null) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <svg className="spinner h-8 w-8 text-indigo-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-          <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
-        </svg>
-      </div>
-    )
+  const findings = decodeFindings(r)
+  if (findings.length === 0) {
+    return {
+      title: 'Soroban Guard — Scan Results',
+      openGraph: { title: 'Soroban Guard — Scan Results' },
+      twitter: { card: 'summary' },
+    }
   }
 
   const counts: Record<Severity, number> = { High: 0, Medium: 0, Low: 0 }
   for (const f of findings) counts[f.severity]++
 
-  const canCopy = typeof navigator !== 'undefined' && navigator.clipboard
+  const title = `Soroban Guard — ${findings.length} finding${findings.length !== 1 ? 's' : ''} detected`
+  const description = `High: ${counts.High} · Medium: ${counts.Medium} · Low: ${counts.Low}`
 
-  return (
-    <div className="flex min-h-screen flex-col">
-      {/* Nav */}
-      <header className="border-b border-[var(--border)] bg-[var(--bg)]/80 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
-          <button
-            onClick={handleScanAnother}
-            className="flex items-center gap-2 text-sm text-slate-400 transition hover:text-white"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-            </svg>
-            Soroban Guard
-          </button>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handleScanAnother}
-              className="rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-indigo-500"
-            >
-              Scan another contract
-            </button>
-            <ThemeToggle />
-          </div>
-        </div>
-      </header>
-
-      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6">
-        {/* Summary bar */}
-        <div className="mb-8">
-          <div className="mb-4 flex items-center justify-between">
-            <h1 className="text-2xl font-bold text-white">Scan Results</h1>
-            <div className="relative">
-              <button
-                onClick={handleCopyJson}
-                disabled={!canCopy}
-                title={canCopy ? 'Copy findings as JSON' : 'Clipboard API unavailable'}
-                className="rounded-lg p-2 text-slate-400 transition hover:bg-[#1a1d27] hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
-              </button>
-              {copied && (
-                <div className="absolute right-0 top-full mt-2 whitespace-nowrap rounded-lg bg-green-600 px-3 py-1 text-xs text-white">
-                  Copied!
-                </div>
-              )}
-            </div>
-          </div>
-          <p className="mb-6 text-sm text-slate-500">
-            {findings.length === 0
-              ? 'No issues detected.'
-              : `${findings.length} finding${findings.length !== 1 ? 's' : ''} detected across your contract.`}
-          </p>
-
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <SummaryCard
-              label="Total Findings"
-              value={findings.length}
-              color="text-white"
-              bg="bg-[#1a1d27]"
-            />
-            <SummaryCard
-              label="High"
-              value={counts.High}
-              color="text-red-400"
-              bg="bg-red-500/5"
-              border="border-red-500/20"
-            />
-            <SummaryCard
-              label="Medium"
-              value={counts.Medium}
-              color="text-amber-400"
-              bg="bg-amber-500/5"
-              border="border-amber-500/20"
-            />
-            <SummaryCard
-              label="Low"
-              value={counts.Low}
-              color="text-sky-400"
-              bg="bg-sky-500/5"
-              border="border-sky-500/20"
-            />
-          </div>
-        </div>
-
-        {/* Findings or empty state */}
-        {findings.length === 0 ? (
-          <EmptyState onScanAnother={handleScanAnother} />
-        ) : (
-          <div>
-            <div className="mb-3 flex items-center justify-between">
-              <h2 className="text-sm font-semibold text-slate-400">
-                Findings — click a row to expand details
-              </h2>
-              <div className="flex gap-2">
-                {(['High', 'Medium', 'Low'] as Severity[]).map(s =>
-                  counts[s] > 0 ? (
-                    <SeverityBadge key={s} severity={s} size="sm" />
-                  ) : null,
-                )}
-              </div>
-            </div>
-            {/* Sort: High → Medium → Low */}
-            <FindingsTable
-              findings={[...findings].sort((a, b) => {
-                const order: Record<Severity, number> = { High: 0, Medium: 1, Low: 2 }
-                return order[a.severity] - order[b.severity]
-              })}
-            />
-          </div>
-        )}
-      </main>
-
-      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
-        Soroban Guard · Veritas Vaults Network
-      </footer>
-    </div>
-  )
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+    twitter: { card: 'summary', title, description },
+  }
 }
 
-function SummaryCard({
-  label,
-  value,
-  color,
-  bg,
-  border = 'border-[var(--border)]',
-}: {
-  label: string
-  value: number
-  color: string
-  bg: string
-  border?: string
-}) {
-  return (
-    <div className={`rounded-xl border ${border} ${bg} px-5 py-4`}>
-      <p className="mb-1 text-xs text-slate-500">{label}</p>
-      <p className={`text-3xl font-bold ${color}`}>{value}</p>
-    </div>
-  )
+export default function ResultsPage({ searchParams }: Props) {
+  return <ResultsClient />
 }

--- a/components/ConfirmModal.tsx
+++ b/components/ConfirmModal.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useEffect, useRef, useId } from 'react'
+import { createPortal } from 'react-dom'
+
+interface Props {
+  title: string
+  description?: string
+  confirmLabel?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function ConfirmModal({
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  onConfirm,
+  onCancel,
+}: Props) {
+  const titleId = useId()
+  const confirmRef = useRef<HTMLButtonElement>(null)
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  // Focus confirm button on open
+  useEffect(() => {
+    confirmRef.current?.focus()
+  }, [])
+
+  // Escape to close + focus trap
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') { onCancel(); return }
+      if (e.key !== 'Tab') return
+      const focusable = [cancelRef.current, confirmRef.current].filter(Boolean) as HTMLElement[]
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (e.shiftKey ? document.activeElement === first : document.activeElement === last) {
+        e.preventDefault()
+        ;(e.shiftKey ? last : first).focus()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onCancel])
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-sm rounded-2xl border border-[#2a2d3a] bg-[#12151f] p-6 shadow-xl"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 id={titleId} className="mb-2 text-base font-semibold text-white">
+          {title}
+        </h2>
+        {description && (
+          <p className="mb-6 text-sm text-slate-400">{description}</p>
+        )}
+        <div className="flex justify-end gap-3">
+          <button
+            ref={cancelRef}
+            onClick={onCancel}
+            className="rounded-lg px-4 py-2 text-sm text-slate-400 transition hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            ref={confirmRef}
+            onClick={onConfirm}
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-500"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/components/ScanInput.tsx
+++ b/components/ScanInput.tsx
@@ -14,7 +14,19 @@ export default function ScanInput({ onScan, loading }: Props) {
   const [code, setCode] = useState('')
   const [repoUrl, setRepoUrl] = useState('')
   const [contractId, setContractId] = useState('')
+  const [normalized, setNormalized] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const normalizedTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function handleContractIdChange(raw: string) {
+    const clean = raw.trim().toUpperCase()
+    setContractId(clean)
+    if (clean !== raw) {
+      if (normalizedTimer.current) clearTimeout(normalizedTimer.current)
+      setNormalized(true)
+      normalizedTimer.current = setTimeout(() => setNormalized(false), 1000)
+    }
+  }
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -122,16 +134,23 @@ export default function ScanInput({ onScan, loading }: Props) {
         </div>
       ) : (
         <div className="space-y-2">
+          <div className="relative">
           <input
             type="text"
             value={contractId}
-            onChange={e => setContractId(e.target.value)}
+            onChange={e => handleContractIdChange(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
             className="w-full rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 font-mono text-sm text-slate-300 placeholder-slate-600 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
             disabled={loading}
             spellCheck={false}
           />
+          {normalized && (
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 rounded bg-indigo-500/20 px-2 py-0.5 text-xs text-indigo-300 transition-opacity duration-500">
+              Normalized
+            </span>
+          )}
+          </div>
           <p className="text-xs text-slate-500">
             Enter a Soroban contract ID (C-address) deployed on Stellar. The scanner
             will fetch the WASM bytecode via Soroban RPC and analyze it.


### PR DESCRIPTION
Closes #35

## What
Adds a reusable `ConfirmModal` component and a `/history` page that uses it for the destructive clear action.

## `components/ConfirmModal.tsx`
- Renders via `createPortal` into `document.body` (no z-index issues)
- `role=dialog`, `aria-modal=true`, `aria-labelledby` pointing to the title
- Focus lands on the Confirm button on open
- Tab/Shift+Tab cycles only between Cancel and Confirm (focus trap)
- Escape key calls `onCancel`
- Backdrop click calls `onCancel`; inner click is stopped from propagating

## `app/history/page.tsx`
- Loads scan history from `localStorage`
- "Clear history" button only shown when entries exist
- Opens `ConfirmModal`; confirm wipes storage and state, cancel dismisses