### PR TITLE
feat: fix rate limit error

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import ScanInput from '@/components/ScanInput'
 import WalletConnect from '@/components/WalletConnect'
 import NetworkBadge from '@/components/NetworkBadge'
 import NetworkHealthBanner from '@/components/NetworkHealthBanner'
 import ThemeToggle from '@/components/ThemeToggle'
-import { scanContract } from '@/lib/api'
+import { scanContract, ApiError } from '@/lib/api'
 import { checkNetworkHealth } from '@/lib/stellar'
 import type { Finding } from '@/types/findings'
 import type { StellarNetwork, ContractScanRecord } from '@/types/stellar'
@@ -17,6 +17,8 @@ export default function HomePage() {
   const router = useRouter()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [countdown, setCountdown] = useState(0)
+  const pendingSourceRef = useRef<string | null>(null)
   const [walletKey, setWalletKey] = useState<string | null>(null)
   const [walletNetwork, setWalletNetwork] = useState<StellarNetwork>(NETWORKS.testnet)
   const [networkHealthy, setNetworkHealthy] = useState(true)
@@ -33,6 +35,28 @@ export default function HomePage() {
     })
   }
 
+  // Countdown timer — ticks every second, auto-retries when it hits zero
+  useEffect(() => {
+    if (countdown <= 0) return
+    const id = setInterval(() => {
+      setCountdown(prev => {
+        if (prev <= 1) {
+          clearInterval(id)
+          // Auto-retry with the pending source
+          if (pendingSourceRef.current !== null) {
+            const src = pendingSourceRef.current
+            pendingSourceRef.current = null
+            handleScan(src)
+          }
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+    return () => clearInterval(id)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [countdown])
+
   async function handleScan(source: string) {
     setLoading(true)
     setError(null)
@@ -44,9 +68,16 @@ export default function HomePage() {
       sessionStorage.setItem('sg_findings', JSON.stringify(data.findings))
       router.push(`/results?r=${encoded}`)
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Unexpected error'
-      setError(msg)
-      setStatusMessage('')
+      if (err instanceof ApiError && err.status === 429 && err.retryAfter) {
+        pendingSourceRef.current = source
+        setCountdown(err.retryAfter)
+        setError(null)
+        setStatusMessage(`Rate limited. Retrying in ${err.retryAfter}s…`)
+      } else {
+        const msg = err instanceof Error ? err.message : 'Unexpected error'
+        setError(msg)
+        setStatusMessage('')
+      }
     } finally {
       setLoading(false)
     }
@@ -141,7 +172,16 @@ export default function HomePage() {
 
           {/* Scan card */}
           <div className="rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] p-6 text-left shadow-2xl">
-            <ScanInput onScan={handleScan} loading={loading} />
+            <ScanInput onScan={handleScan} loading={loading} countdown={countdown} />
+
+            {countdown > 0 && (
+              <div className="mt-4 flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-400">
+                <svg className="mt-0.5 h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span>Rate limited — retrying automatically in {countdown}s</span>
+              </div>
+            )}
 
             {error && (
               <div className="mt-4 flex items-start gap-3 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">

--- a/components/ScanInput.tsx
+++ b/components/ScanInput.tsx
@@ -7,9 +7,10 @@ type InputMode = 'code' | 'github' | 'contractId'
 interface Props {
   onScan: (source: string) => void
   loading: boolean
+  countdown?: number
 }
 
-export default function ScanInput({ onScan, loading }: Props) {
+export default function ScanInput({ onScan, loading, countdown = 0 }: Props) {
   const [mode, setMode] = useState<InputMode>('code')
   const [code, setCode] = useState('')
   const [repoUrl, setRepoUrl] = useState('')
@@ -37,8 +38,11 @@ export default function ScanInput({ onScan, loading }: Props) {
     }
   }
 
+  const isRateLimited = countdown > 0
+
   const canSubmit =
     !loading &&
+    !isRateLimited &&
     (mode === 'code'
       ? code.trim().length > 0
       : mode === 'github'
@@ -146,7 +150,14 @@ export default function ScanInput({ onScan, loading }: Props) {
           disabled={!canSubmit}
           className="flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
         >
-          {loading ? (
+          {isRateLimited ? (
+            <>
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Rate limited — retry in {countdown}s
+            </>
+          ) : loading ? (
             <>
               <svg className="spinner h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
                 <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />

--- a/e2e/rate-limit.spec.ts
+++ b/e2e/rate-limit.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Helpers to mock fetch with a given response factory.
+ * The factory receives the call count so tests can simulate
+ * 429 on the first call and 200 on the retry.
+ */
+function mockFetch(
+  page: import('@playwright/test').Page,
+  factory: (callCount: number) => { status: number; body: string; headers?: Record<string, string> },
+) {
+  return page.addInitScript(`
+    (() => {
+      let callCount = 0;
+      const originalFetch = window.fetch;
+      window.fetch = async (input, init) => {
+        const url = typeof input === 'string' ? input : input.url;
+        if (url.includes('/scan') && init?.method === 'POST') {
+          const n = callCount++;
+          const factory = ${factory.toString()};
+          const { status, body, headers = {} } = factory(n);
+          return new Response(body, { status, headers: { 'Content-Type': 'application/json', ...headers } });
+        }
+        return originalFetch(input, init);
+      };
+    })();
+  `)
+}
+
+const mockFindings = JSON.stringify({ findings: [] })
+
+test.describe('Rate limit (429) handling', () => {
+  test('shows countdown banner when API returns 429', async ({ page }) => {
+    await mockFetch(page, () => ({
+      status: 429,
+      body: 'Rate limited',
+      headers: { 'Retry-After': '5' },
+    }))
+
+    await page.goto('/')
+    await page.locator('textarea').first().fill('pub fn test() {}')
+    await page.locator('button:has-text("Scan Contract")').click()
+
+    await expect(page.locator('text=Rate limited — retrying automatically in')).toBeVisible()
+  })
+
+  test('scan button is disabled during countdown', async ({ page }) => {
+    await mockFetch(page, () => ({
+      status: 429,
+      body: 'Rate limited',
+      headers: { 'Retry-After': '10' },
+    }))
+
+    await page.goto('/')
+    await page.locator('textarea').first().fill('pub fn test() {}')
+    await page.locator('button:has-text("Scan Contract")').click()
+
+    // Button should now show the countdown and be disabled
+    const btn = page.locator('button:has-text("Rate limited — retry in")')
+    await expect(btn).toBeVisible()
+    await expect(btn).toBeDisabled()
+  })
+
+  test('auto-retries exactly once when countdown reaches zero', async ({ page }) => {
+    // First call → 429 with 2s retry, second call → 200
+    await mockFetch(page, (n) =>
+      n === 0
+        ? { status: 429, body: 'Rate limited', headers: { 'Retry-After': '2' } }
+        : { status: 200, body: mockFindings },
+    )
+
+    await page.goto('/')
+    await page.locator('textarea').first().fill('pub fn test() {}')
+    await page.locator('button:has-text("Scan Contract")').click()
+
+    // Countdown banner appears
+    await expect(page.locator('text=Rate limited — retrying automatically in')).toBeVisible()
+
+    // After countdown expires the retry fires and navigates to /results
+    await page.waitForURL(/\/results/, { timeout: 10_000 })
+    await expect(page).toHaveURL(/\/results/)
+  })
+
+  test('non-429 errors still show generic error message', async ({ page }) => {
+    await mockFetch(page, () => ({
+      status: 500,
+      body: 'Internal Server Error',
+    }))
+
+    await page.goto('/')
+    await page.locator('textarea').first().fill('pub fn test() {}')
+    await page.locator('button:has-text("Scan Contract")').click()
+
+    // Generic error banner should appear, no countdown
+    await expect(page.locator('text=Internal Server Error')).toBeVisible()
+    await expect(page.locator('text=Rate limited')).not.toBeVisible()
+  })
+})

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,12 +3,16 @@ import type { ScanRequest, ScanResponse } from '@/types/findings'
 const API_BASE = (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001').replace(/\/$/, '')
 
 export class ApiError extends Error {
+  public retryAfter?: number
+
   constructor(
     public status: number,
     message: string,
+    retryAfter?: number,
   ) {
     super(message)
     this.name = 'ApiError'
+    this.retryAfter = retryAfter
   }
 }
 
@@ -22,6 +26,11 @@ export async function scanContract(source: string): Promise<ScanResponse> {
   })
 
   if (!res.ok) {
+    if (res.status === 429) {
+      const retryAfterHeader = res.headers.get('Retry-After')
+      const retryAfter = retryAfterHeader ? Math.ceil(parseFloat(retryAfterHeader)) : 60
+      throw new ApiError(429, 'Rate limited', retryAfter)
+    }
     const text = await res.text().catch(() => 'Unknown error')
     throw new ApiError(res.status, text || `HTTP ${res.status}`)
   }


### PR DESCRIPTION
##Summary
Implements a live countdown timer and auto-retry logic when the API 
returns a 429 Too Many Requests response, replacing the generic 
error message with a clear user-facing indicator.

## Changes
- `lib/api.ts`: Detects 429 status and parses `Retry-After` header
- `app/page.tsx`: Shows "Rate limited — retry in Xs" live countdown, 
  auto-retries when countdown reaches zero
- `components/ScanInput.tsx`: Disables scan button during countdown, 
  re-enables on completion

## Testing
- [ ] 429 response shows live countdown correctly
- [ ] Scan button disabled during countdown
- [ ] Auto-retry fires once when countdown hits zero
- [ ] Other error codes still show generic error message








closes #25 