### PR TITLE
ci: add GitHub Actions CI pipeline (#36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
+      - run: npm run build

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import NetworkBadge from '@/components/NetworkBadge'
 import NetworkHealthBanner from '@/components/NetworkHealthBanner'
 import ThemeToggle from '@/components/ThemeToggle'
 import { scanContract } from '@/lib/api'
+import { encodeFindings } from '@/lib/share'
 import { checkNetworkHealth } from '@/lib/stellar'
 import type { Finding } from '@/types/findings'
 import type { StellarNetwork, ContractScanRecord } from '@/types/stellar'
@@ -21,6 +22,7 @@ export default function HomePage() {
   const [walletNetwork, setWalletNetwork] = useState<StellarNetwork>(NETWORKS.testnet)
   const [networkHealthy, setNetworkHealthy] = useState(true)
   const [statusMessage, setStatusMessage] = useState('')
+  const [scanHistory] = useState<ContractScanRecord[]>([])
 
   function handleWalletConnect(publicKey: string, network: StellarNetwork) {
     setWalletKey(publicKey)
@@ -42,6 +44,7 @@ export default function HomePage() {
       setStatusMessage(`Scan complete. ${data.findings.length} finding${data.findings.length !== 1 ? 's' : ''} detected.`)
       // Store results in sessionStorage so the results page can read them
       sessionStorage.setItem('sg_findings', JSON.stringify(data.findings))
+      const encoded = encodeFindings(data.findings)
       router.push(`/results?r=${encoded}`)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unexpected error'

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -49,6 +49,11 @@ export default function ResultsPage() {
     setTimeout(() => setCopied(false), 2000)
   }
 
+  function handleCopyJson() {
+    if (!canCopy || !findings) return
+    navigator.clipboard.writeText(JSON.stringify(findings, null, 2))
+  }
+
   if (findings === null) {
     return (
       <div className="flex min-h-screen items-center justify-center">

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -44,7 +44,7 @@ test.describe('Soroban Guard E2E Smoke Tests', () => {
     await page.addInitScript(() => {
       const originalFetch = window.fetch
       window.fetch = async (input, init) => {
-        const url = typeof input === 'string' ? input : input.url
+        const url = typeof input === 'string' ? input : (input as Request).url
         if (url.includes('/scan') && init?.method === 'POST') {
           return new Response(JSON.stringify({ findings: mockFindings }), {
             status: 200,
@@ -83,7 +83,7 @@ test.describe('Soroban Guard E2E Smoke Tests', () => {
     await page.addInitScript(() => {
       const originalFetch = window.fetch
       window.fetch = async (input, init) => {
-        const url = typeof input === 'string' ? input : input.url
+        const url = typeof input === 'string' ? input : (input as Request).url
         if (url.includes('/scan') && init?.method === 'POST') {
           return new Response(JSON.stringify({ findings: mockFindings }), {
             status: 200,
@@ -118,7 +118,7 @@ test.describe('Soroban Guard E2E Smoke Tests', () => {
     await page.addInitScript(() => {
       const originalFetch = window.fetch
       window.fetch = async (input, init) => {
-        const url = typeof input === 'string' ? input : input.url
+        const url = typeof input === 'string' ? input : (input as Request).url
         if (url.includes('/scan') && init?.method === 'POST') {
           return new Response(JSON.stringify({ findings: mockFindings }), {
             status: 200,
@@ -150,7 +150,7 @@ test.describe('Soroban Guard E2E Smoke Tests', () => {
     await page.addInitScript(() => {
       const originalFetch = window.fetch
       window.fetch = async (input, init) => {
-        const url = typeof input === 'string' ? input : input.url
+        const url = typeof input === 'string' ? input : (input as Request).url
         if (url.includes('/scan') && init?.method === 'POST') {
           return new Response(JSON.stringify({ findings: mockFindings }), {
             status: 200,

--- a/lib/stellar.ts
+++ b/lib/stellar.ts
@@ -41,7 +41,6 @@ export async function fetchContractInfo(
   if (res.status === 404) return null
   if (!res.ok) throw new Error(`Horizon error ${res.status}: ${await res.text()}`)
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const data = (await res.json()) as any
   return {
     contractId,
@@ -72,7 +71,6 @@ async function rpcCall<T>(
     body: JSON.stringify(body),
   })
   if (!res.ok) throw new Error(`RPC HTTP error ${res.status}`)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const json = (await res.json()) as any
   if (json.error) throw new Error(`RPC error: ${json.error.message}`)
   return json.result as T

--- a/lib/wallet.ts
+++ b/lib/wallet.ts
@@ -22,7 +22,6 @@ interface FreighterAPI {
 
 function getFreighter(): FreighterAPI | null {
   if (typeof window === 'undefined') return null
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (window as any).freighter ?? null
 }
 


### PR DESCRIPTION
## Summary

Closes #36. Adds a CI pipeline that runs on every push and PR to `main`.

## What's in this PR

**`.github/workflows/ci.yml`** (new)
- Triggers on `push` and `pull_request` to `main`
- Steps: `npm ci` → `npm run lint` → `npx tsc --noEmit` → `npm run build`
- Caches `~/.npm` between runs via `actions/cache@v4`

**Pre-existing errors fixed** (required to make CI green on `main`):
- `app/page.tsx`: `encoded` was undefined — added `encodeFindings` import and call; `scanHistory` was referenced but never declared — added state
- `app/results/page.tsx`: `handleCopyJson` was called but never defined — added the function
- `e2e/smoke.spec.ts`: `input.url` on `Request | URL` — cast to `Request` to satisfy TypeScript
- `lib/stellar.ts`, `lib/wallet.ts`: removed stale `@typescript-eslint/no-explicit-any` disable comments (plugin not installed, causing lint errors)

## Tested locally

```
✔ npm run lint       — No ESLint warnings or errors
✔ npx tsc --noEmit   — No type errors
✔ npm run build      — Build succeeded
```