### PR TITLE
feat: skip link, mobile FAB, network selector, and char limit guard

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,6 +34,12 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-[var(--bg)] text-[var(--text)] antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-indigo-600 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:outline-none"
+        >
+          Skip to main content
+        </a>
         <WalletProvider>{children}</WalletProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import ScanInput from '@/components/ScanInput'
 import WalletConnect from '@/components/WalletConnect'
 import NetworkBadge from '@/components/NetworkBadge'
+import NetworkSelector, { getStoredNetwork } from '@/components/NetworkSelector'
 import NetworkHealthBanner from '@/components/NetworkHealthBanner'
 import ThemeToggle from '@/components/ThemeToggle'
 import { scanContract, ApiError } from '@/lib/api'
@@ -32,6 +33,9 @@ function HomePage() {
   const [networkHealthy, setNetworkHealthy] = useState(true)
   const [statusMessage, setStatusMessage] = useState('')
   const [scanHistory] = useState<ContractScanRecord[]>([])
+  const [manualNetwork, setManualNetwork] = useState(() => getStoredNetwork())
+
+  const activeNetwork = walletKey ? walletNetwork : manualNetwork
 
   async function handleScan(source: string, mode: 'code' | 'github' | 'contractId' = 'code') {
     setLoading(true)
@@ -44,7 +48,7 @@ function HomePage() {
     
     try {
       const t0 = Date.now()
-      const data = await scanContract(source)
+      const data = await scanContract(source, activeNetwork)
       const duration = ((Date.now() - t0) / 1000).toFixed(1)
       setStatusMessage(`Scan complete. ${data.findings.length} finding${data.findings.length !== 1 ? 's' : ''} detected.`)
       // Store results in sessionStorage so the results page can read them
@@ -135,12 +139,15 @@ function HomePage() {
               Veritas Vaults Network
             </a>
             <ThemeToggle />
+            {!walletKey && (
+              <NetworkSelector value={manualNetwork} onChange={setManualNetwork} />
+            )}
             <WalletConnect />
           </div>
         </div>
       </header>
 
-      <main className="flex-1">
+      <main id="main-content" className="flex-1">
         {/* Hero */}
         <section className="mx-auto max-w-3xl px-4 pb-12 pt-20 text-center sm:px-6">
           <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-400">

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -115,7 +115,7 @@ export function generateMetadata({ searchParams }: Props): Metadata {
         </div>
       </header>
 
-      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6">
+      <main id="main-content" className="mx-auto w-full max-w-6xl flex-1 px-4 pb-24 pt-10 sm:pb-10 sm:px-6">
         {/* Summary bar */}
         <div className="mb-8">
           <div className="mb-4 flex items-center justify-between">
@@ -220,6 +220,18 @@ export function generateMetadata({ searchParams }: Props): Metadata {
           </div>
         )}
       </main>
+
+      {/* Mobile FAB */}
+      <button
+        onClick={handleScanAnother}
+        aria-label="Scan another contract"
+        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-indigo-500 sm:hidden"
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+        </svg>
+        New scan
+      </button>
 
       <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
         Soroban Guard · Veritas Vaults Network

--- a/components/NetworkSelector.tsx
+++ b/components/NetworkSelector.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { NETWORKS, type StellarNetwork } from '@/types/stellar'
+
+const STORAGE_KEY = 'sg_selected_network'
+
+interface Props {
+  value: StellarNetwork
+  onChange: (network: StellarNetwork) => void
+}
+
+export function getStoredNetwork(): StellarNetwork {
+  if (typeof window === 'undefined') return NETWORKS.mainnet
+  const stored = localStorage.getItem(STORAGE_KEY)
+  return (stored && NETWORKS[stored]) ? NETWORKS[stored] : NETWORKS.mainnet
+}
+
+export default function NetworkSelector({ value, onChange }: Props) {
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const network = NETWORKS[e.target.value]
+    if (!network) return
+    localStorage.setItem(STORAGE_KEY, e.target.value)
+    onChange(network)
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor="network-selector" className="text-xs text-slate-400">
+        Network
+      </label>
+      <select
+        id="network-selector"
+        value={value.name}
+        onChange={handleChange}
+        className="rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-2 py-1 text-xs text-slate-300 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
+      >
+        <option value="mainnet">Mainnet</option>
+        <option value="testnet">Testnet</option>
+        <option value="futurenet">Futurenet</option>
+      </select>
+    </div>
+  )
+}

--- a/components/ScanInput.tsx
+++ b/components/ScanInput.tsx
@@ -71,7 +71,7 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
     !loading &&
     !isRateLimited &&
     (mode === 'code'
-      ? code.trim().length > 0
+      ? code.trim().length > 0 && code.length <= 100000
       : mode === 'github'
         ? repoUrl.trim().length > 0 && validateGithub(repoUrl).valid
         : contractId.trim().length > 0 && contractValid)
@@ -130,9 +130,17 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
             disabled={loading}
           />
           {code.length > 0 && (
-            <span className="absolute bottom-3 right-3 text-xs text-slate-600">
+            <span className={`absolute bottom-3 right-3 text-xs ${
+              code.length > 100000 ? 'text-red-400' : code.length > 50000 ? 'text-amber-400' : 'text-slate-600'
+            }`}>
               {code.length.toLocaleString()} chars
             </span>
+          )}
+          {code.length > 100000 && (
+            <p className="mt-1.5 text-xs text-red-400">Contract too large. Maximum 100,000 characters.</p>
+          )}
+          {code.length > 50000 && code.length <= 100000 && (
+            <p className="mt-1.5 text-xs text-amber-400">Large contract — scan may be slow</p>
           )}
         </div>
       ) : mode === 'github' ? (

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,5 @@
 import type { ScanRequest, ScanResponse } from '@/types/findings'
+import type { StellarNetwork } from '@/types/stellar'
 
 const API_BASE = (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001').replace(/\/$/, '')
 
@@ -16,12 +17,15 @@ export class ApiError extends Error {
   }
 }
 
-export async function scanContract(source: string): Promise<ScanResponse> {
+export async function scanContract(source: string, network?: StellarNetwork): Promise<ScanResponse> {
   const body: ScanRequest = { source }
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (network) headers['X-Network'] = network.name
 
   const res = await fetch(`${API_BASE}/scan`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(body),
   })
 


### PR DESCRIPTION
closes #50 
closes #46 
closes #49 
closes #61 



## Accessibility — Skip to main content
- app/layout.tsx: add visually-hidden skip link as the first focusable element in <body>; visible only on focus (sr-only / focus:not-sr-only)
- app/page.tsx: add id='main-content' to <main> so the skip link target exists
- app/results/page.tsx: same id='main-content' on <main>

## UX — Mobile floating action button (results page)
- app/results/page.tsx: fixed-position FAB (bottom-right, sm:hidden) with shield icon + 'New scan' label; aria-label='Scan another contract'
- Bottom padding on <main> increased to pb-24 on mobile (sm:pb-10) so the FAB never overlaps the last finding row

## Feature — Manual network selector
- components/NetworkSelector.tsx: new dropdown over NETWORKS (Mainnet / Testnet / Futurenet); persists choice to localStorage (sg_selected_network); exports getStoredNetwork() for SSR-safe initialisation
- app/page.tsx: manualNetwork state seeded from getStoredNetwork(); activeNetwork = walletKey ? walletNetwork : manualNetwork so wallet always overrides; NetworkSelector rendered in header only when wallet is not connected; scanContract called with activeNetwork
- lib/api.ts: scanContract accepts optional StellarNetwork and forwards it as X-Network request header so the core API knows which RPC to target

## Validation — Contract size limits (ScanInput)
- components/ScanInput.tsx: character counter turns amber >50 000 chars and red >100 000 chars; amber warning 'Large contract — scan may be slow' shown between 50 k and 100 k; red error 'Contract too large. Maximum 100,000 characters.' shown above 100 k; submit button disabled above 100 k

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
