### PR TITLE
Add Try sample contract button for first-time users

### DIFF
--- a/components/ScanInput.tsx
+++ b/components/ScanInput.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useRef } from 'react'
+import { SAMPLE_CONTRACT } from '@/lib/sampleContract'
 
 type InputMode = 'code' | 'github' | 'contractId'
 
@@ -178,6 +179,23 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
             Enter a Soroban contract ID (C-address) deployed on Stellar. The scanner
             will fetch the WASM bytecode via Soroban RPC and analyze it.
           </p>
+        </div>
+      )}
+
+      {/* Try sample — code mode only */}
+      {mode === 'code' && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => setCode(SAMPLE_CONTRACT)}
+            disabled={loading}
+            className="flex items-center gap-1.5 rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-1.5 text-xs text-slate-400 transition hover:border-indigo-500/50 hover:text-indigo-300 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+            </svg>
+            Try sample contract
+          </button>
         </div>
       )}
 

--- a/lib/sampleContract.ts
+++ b/lib/sampleContract.ts
@@ -1,0 +1,42 @@
+// A short Soroban contract with intentional vulnerabilities for demo purposes.
+// Vulnerabilities:
+//   1. Integer overflow: unchecked arithmetic on u32 balance
+//   2. Missing authorization: anyone can call withdraw()
+//   3. Unprotected admin setter: set_admin has no auth check
+
+export const SAMPLE_CONTRACT = `#![no_std]
+use soroban_sdk::{contract, contractimpl, contractstorage, symbol_short, Address, Env};
+
+#[contract]
+pub struct VulnerableVault;
+
+#[contractimpl]
+impl VulnerableVault {
+    /// Deposit tokens — balance can silently overflow (u32 wraps around)
+    pub fn deposit(env: Env, user: Address, amount: u32) {
+        let key = symbol_short!("bal");
+        let current: u32 = env.storage().instance().get(&key).unwrap_or(0);
+        // BUG: unchecked addition — wraps on overflow instead of panicking
+        env.storage().instance().set(&key, &(current + amount));
+    }
+
+    /// Withdraw tokens — no authorization check, anyone can drain the vault
+    pub fn withdraw(env: Env, amount: u32) {
+        let key = symbol_short!("bal");
+        let current: u32 = env.storage().instance().get(&key).unwrap_or(0);
+        // BUG: no caller.require_auth() — any account can withdraw
+        let new_bal = current.checked_sub(amount).expect("insufficient funds");
+        env.storage().instance().set(&key, &new_bal);
+    }
+
+    /// Change admin — no auth guard, anyone can become admin
+    pub fn set_admin(env: Env, new_admin: Address) {
+        // BUG: missing new_admin.require_auth() or existing admin check
+        env.storage().instance().set(&symbol_short!("admin"), &new_admin);
+    }
+
+    pub fn balance(env: Env) -> u32 {
+        env.storage().instance().get(&symbol_short!("bal")).unwrap_or(0)
+    }
+}
+`


### PR DESCRIPTION

closes #44 

PR description:
New users landing on the scan page have no obvious starting point. This adds a "Try sample contract" button (visible in code mode only) that pre-fills the textarea with a short vulnerable Soroban contract from `lib/sampleContract.ts`. The sample demonstrates three real vulnerability classes — unchecked integer overflow, missing `require_auth` on a withdraw function, and an unprotected admin setter — giving users an immediate, meaningful scan result without needing their own contract on hand.