### PR TITLE
feat: add shareable workspace URL encoding source and findings (#119)

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import type { Finding, Severity } from '@/types/findings'
-import { decodeFindings } from '@/lib/share'
+import { decodeFindings, encodeWorkspace } from '@/lib/share'
 import { exportEmail } from '@/lib/export'
 import { getAllScanHistory } from '@/lib/history'
 import { diffFindings } from '@/lib/diffFindings'
@@ -23,6 +23,10 @@ export default function ResultsPage() {
   const [findings, setFindings] = useState<Finding[] | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [showGithubModal, setShowGithubModal] = useState(false)
+  const [prevFindings, setPrevFindings] = useState<Finding[] | null>(null)
+  const [showDiff, setShowDiff] = useState(false)
+  const [groupView, setGroupView] = useState<'flat' | 'function'>('flat')
+  const [navIndex, setNavIndex] = useState<number | null>(null)
 
   useEffect(() => {
     const encoded = searchParams.get('r')
@@ -76,6 +80,15 @@ export default function ResultsPage() {
     const url = window.location.href
     navigator.clipboard.writeText(url)
     show('Link copied!', 'success')
+  }
+
+  function handleShareWorkspace() {
+    if (!findings) return
+    const source = sessionStorage.getItem('sg_source_code') ?? ''
+    const token = encodeWorkspace(source, findings)
+    const url = `${window.location.origin}/workspace/${token}`
+    navigator.clipboard.writeText(url)
+    show('Workspace link copied!', 'success')
   }
 
   if (findings === null) {
@@ -136,6 +149,16 @@ export default function ResultsPage() {
                 Create GitHub Issues
               </button>
             )}
+            <button
+              onClick={handleShareWorkspace}
+              disabled={!canCopy}
+              className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white disabled:opacity-40"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+              </svg>
+              Share workspace
+            </button>
             <button
               onClick={handleScanAnother}
               className="rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-indigo-500"

--- a/app/workspace/[token]/page.tsx
+++ b/app/workspace/[token]/page.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import type { Finding, Severity } from '@/types/findings'
+import { decodeWorkspace } from '@/lib/share'
+import FindingsTable from '@/components/FindingsTable'
+import EmptyState from '@/components/EmptyState'
+import SeverityBadge from '@/components/SeverityBadge'
+import ThemeToggle from '@/components/ThemeToggle'
+
+export default function WorkspacePage() {
+  const params = useParams()
+  const router = useRouter()
+  const [findings, setFindings] = useState<Finding[] | null>(null)
+  const [source, setSource] = useState<string | null>(null)
+  const [sourceOpen, setSourceOpen] = useState(false)
+
+  useEffect(() => {
+    const token = typeof params.token === 'string' ? params.token : Array.isArray(params.token) ? params.token[0] : ''
+    const ws = decodeWorkspace(token)
+    if (!ws) {
+      router.replace('/')
+      return
+    }
+    setFindings(ws.findings)
+    setSource(ws.source)
+  }, [params.token, router])
+
+  if (findings === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <svg className="spinner h-8 w-8 text-indigo-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+          <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
+        </svg>
+      </div>
+    )
+  }
+
+  const counts: Record<Severity, number> = { Critical: 0, High: 0, Medium: 0, Low: 0 }
+  for (const f of findings) counts[f.severity]++
+
+  const sorted = [...findings].sort((a, b) => {
+    const order: Record<Severity, number> = { Critical: 0, High: 1, Medium: 2, Low: 3 }
+    return order[a.severity] - order[b.severity]
+  })
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b border-[var(--border)] bg-[var(--bg)]/80 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+          <a href="/" className="flex items-center gap-2 text-sm text-slate-400 transition hover:text-white">
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            Soroban Guard
+          </a>
+          <div className="flex items-center gap-3">
+            <span className="rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-300">
+              Shared workspace
+            </span>
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6">
+        <div className="mb-8">
+          <h1 className="mb-2 text-2xl font-bold text-white">Shared Scan Results</h1>
+          <p className="mb-6 text-sm text-slate-500">
+            {findings.length === 0
+              ? 'No issues detected.'
+              : `${findings.length} finding${findings.length !== 1 ? 's' : ''} detected.`}
+          </p>
+
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <SummaryCard label="Total" value={findings.length} color="text-white" bg="bg-[#1a1d27]" />
+            <SummaryCard label="High" value={counts.High} color="text-red-400" bg="bg-red-500/5" border="border-red-500/20" />
+            <SummaryCard label="Medium" value={counts.Medium} color="text-amber-400" bg="bg-amber-500/5" border="border-amber-500/20" />
+            <SummaryCard label="Low" value={counts.Low} color="text-sky-400" bg="bg-sky-500/5" border="border-sky-500/20" />
+          </div>
+        </div>
+
+        {/* Collapsible source panel */}
+        {source && (
+          <div className="mb-6 rounded-xl border border-[var(--border)] overflow-hidden">
+            <button
+              onClick={() => setSourceOpen(v => !v)}
+              className="flex w-full items-center justify-between px-5 py-3 text-sm font-medium text-slate-300 hover:bg-[var(--bg-hover)] transition-colors"
+              aria-expanded={sourceOpen}
+            >
+              <span className="flex items-center gap-2">
+                <svg className="h-4 w-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                </svg>
+                Contract source
+                <span className="text-xs text-slate-500 font-normal">(read-only)</span>
+              </span>
+              <svg
+                className={`h-4 w-4 text-slate-500 transition-transform ${sourceOpen ? 'rotate-180' : ''}`}
+                fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            {sourceOpen && (
+              <div className="max-h-96 overflow-auto border-t border-[var(--border)] bg-[#0d0f17]">
+                <table className="w-full border-collapse text-xs">
+                  <tbody>
+                    {source.split('\n').map((line, i) => (
+                      <tr key={i}>
+                        <td className="select-none w-10 px-3 py-0.5 text-right font-mono text-slate-600" aria-hidden="true">
+                          {i + 1}
+                        </td>
+                        <td className="px-3 py-0.5 font-mono whitespace-pre text-slate-300">
+                          {line || ' '}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+
+        {findings.length === 0 ? (
+          <EmptyState onScanAnother={() => router.push('/')} />
+        ) : (
+          <div>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-slate-400">Findings — click a row to expand details</h2>
+              <div className="flex gap-2">
+                {(['High', 'Medium', 'Low'] as Severity[]).map(s =>
+                  counts[s] > 0 ? <SeverityBadge key={s} severity={s} size="sm" /> : null,
+                )}
+              </div>
+            </div>
+            <FindingsTable findings={sorted} />
+          </div>
+        )}
+      </main>
+
+      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
+        Soroban Guard · Veritas Vaults Network
+      </footer>
+    </div>
+  )
+}
+
+function SummaryCard({
+  label, value, color, bg, border = 'border-[var(--border)]',
+}: {
+  label: string; value: number; color: string; bg: string; border?: string
+}) {
+  return (
+    <div className={`rounded-xl border ${border} ${bg} px-5 py-4`}>
+      <p className="mb-1 text-xs text-slate-500">{label}</p>
+      <p className={`text-3xl font-bold ${color}`}>{value}</p>
+    </div>
+  )
+}

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -13,3 +13,22 @@ export function decodeFindings(param: string): Finding[] {
     return []
   }
 }
+
+export interface Workspace {
+  source: string
+  findings: Finding[]
+}
+
+export function encodeWorkspace(source: string, findings: Finding[]): string {
+  const json = JSON.stringify({ source, findings } satisfies Workspace)
+  return encodeURIComponent(btoa(json))
+}
+
+export function decodeWorkspace(param: string): Workspace | null {
+  try {
+    const json = atob(decodeURIComponent(param))
+    return JSON.parse(json) as Workspace
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
- Extend lib/share.ts with encodeWorkspace/decodeWorkspace helpers
- Add app/workspace/[token]/page.tsx to render shared workspace read-only
- Add collapsible source panel on workspace page
- Add 'Share workspace' button to ResultsClient that copies workspace URL

Closes #119

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
