### PR TITLE
feat: add portfolio analytics page (#118)

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { getAllScanHistory } from '@/lib/history'
+import { computeAnalytics, type Analytics } from '@/lib/analytics'
+import type { ContractScanRecord } from '@/types/stellar'
+import ThemeToggle from '@/components/ThemeToggle'
+
+const MIN_RECORDS = 3
+
+export default function AnalyticsPage() {
+  const [records, setRecords] = useState<ContractScanRecord[] | null>(null)
+  const [analytics, setAnalytics] = useState<Analytics | null>(null)
+
+  useEffect(() => {
+    const all = getAllScanHistory()
+    setRecords(all)
+    setAnalytics(computeAnalytics(all))
+  }, [])
+
+  if (records === null || analytics === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <svg className="spinner h-8 w-8 text-indigo-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+          <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
+        </svg>
+      </div>
+    )
+  }
+
+  const isEmpty = records.length < MIN_RECORDS
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b border-[var(--border)] bg-[var(--bg)]/80 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-4 sm:px-6">
+          <a href="/history" className="flex items-center gap-2 text-sm text-slate-400 transition hover:text-white">
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            Scan History
+          </a>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-10 sm:px-6">
+        <h1 className="mb-2 text-2xl font-bold text-white">Portfolio Analytics</h1>
+        <p className="mb-8 text-sm text-slate-500">Aggregate statistics across all scans in your history.</p>
+
+        {isEmpty ? (
+          <div className="flex flex-col items-center justify-center rounded-xl border border-[var(--border)] bg-[#12151f] py-20 text-center">
+            <svg className="mb-4 h-10 w-10 text-slate-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            <p className="text-sm font-medium text-slate-400">Not enough data yet</p>
+            <p className="mt-1 text-xs text-slate-600">
+              Run at least {MIN_RECORDS} scans to see analytics.{' '}
+              {records.length > 0 && `(${records.length} of ${MIN_RECORDS} so far)`}
+            </p>
+            <a
+              href="/"
+              className="mt-6 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500"
+            >
+              Scan a contract
+            </a>
+          </div>
+        ) : (
+          <>
+            {/* Stat cards */}
+            <div className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <StatCard label="Total scans" value={analytics.totalScans} color="text-white" />
+              <StatCard label="Avg findings / scan" value={analytics.avgScore} color="text-indigo-400" />
+              <StatCard label="Total high" value={analytics.totalFindings.high} color="text-red-400" />
+              <StatCard label="Total medium" value={analytics.totalFindings.medium} color="text-amber-400" />
+            </div>
+
+            {/* Top checks bar chart */}
+            <div className="rounded-xl border border-[var(--border)] bg-[#12151f] p-6">
+              <h2 className="mb-5 text-sm font-semibold text-slate-300">Top 5 most frequent checks</h2>
+              {analytics.topChecks.length === 0 ? (
+                <p className="text-sm text-slate-500">No findings recorded yet.</p>
+              ) : (
+                <TopChecksChart checks={analytics.topChecks} />
+              )}
+            </div>
+          </>
+        )}
+      </main>
+
+      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
+        Soroban Guard · Veritas Vaults Network
+      </footer>
+    </div>
+  )
+}
+
+function StatCard({ label, value, color }: { label: string; value: number; color: string }) {
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[#12151f] px-5 py-4">
+      <p className="mb-1 text-xs text-slate-500">{label}</p>
+      <p className={`text-3xl font-bold ${color}`}>{value}</p>
+    </div>
+  )
+}
+
+function TopChecksChart({ checks }: { checks: { name: string; count: number }[] }) {
+  const max = checks[0]?.count ?? 1
+  return (
+    <ul className="space-y-3" role="list" aria-label="Top checks by frequency">
+      {checks.map(({ name, count }) => (
+        <li key={name}>
+          <div className="mb-1 flex items-center justify-between text-xs">
+            <span className="font-mono text-slate-300">{name}</span>
+            <span className="text-slate-500">{count}</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-[#1a1d27]">
+            <div
+              className="h-full rounded-full bg-indigo-500 transition-all"
+              style={{ width: `${(count / max) * 100}%` }}
+              role="progressbar"
+              aria-valuenow={count}
+              aria-valuemax={max}
+              aria-label={name}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -43,14 +43,22 @@ export default function HistoryPage() {
     <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-white">Scan History</h1>
-        {entries.length > 0 && (
-          <button
-            onClick={() => setShowConfirm(true)}
-            className="rounded-lg border border-red-500/30 px-4 py-2 text-sm text-red-400 transition hover:bg-red-500/10"
+        <div className="flex items-center gap-3">
+          <a
+            href="/analytics"
+            className="rounded-lg border border-[#2a2d3a] px-4 py-2 text-sm text-slate-400 transition hover:text-white"
           >
-            Clear history
-          </button>
-        )}
+            Analytics
+          </a>
+          {entries.length > 0 && (
+            <button
+              onClick={() => setShowConfirm(true)}
+              className="rounded-lg border border-red-500/30 px-4 py-2 text-sm text-red-400 transition hover:bg-red-500/10"
+            >
+              Clear history
+            </button>
+          )}
+        </div>
       </div>
 
       {entries.length === 0 ? (

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,38 @@
+import type { ContractScanRecord } from '@/types/stellar'
+
+export interface Analytics {
+  totalScans: number
+  avgScore: number
+  topChecks: { name: string; count: number }[]
+  totalFindings: { high: number; medium: number; low: number }
+}
+
+export function computeAnalytics(records: ContractScanRecord[]): Analytics {
+  const totalScans = records.length
+
+  const avgScore =
+    totalScans === 0
+      ? 0
+      : Math.round(
+          records.reduce((sum, r) => sum + r.findingCount, 0) / totalScans,
+        )
+
+  const checkCounts: Record<string, number> = {}
+  const totals = { high: 0, medium: 0, low: 0 }
+
+  for (const record of records) {
+    totals.high += record.highCount
+    totals.medium += record.mediumCount
+    totals.low += record.lowCount
+    for (const f of record.findings) {
+      checkCounts[f.check_name] = (checkCounts[f.check_name] ?? 0) + 1
+    }
+  }
+
+  const topChecks = Object.entries(checkCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([name, count]) => ({ name, count }))
+
+  return { totalScans, avgScore, topChecks, totalFindings: totals }
+}


### PR DESCRIPTION
- Add lib/analytics.ts with computeAnalytics() returning totalScans, avgScore, topChecks (top 5 by frequency), and totalFindings by severity
- Add app/analytics/page.tsx with stat cards and top-checks bar chart
- Show empty state when history has fewer than 3 records
- Link to /analytics from the history page header

Closes #118

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
