### PR TITLE
feat: add Notion export for scan findings (#132)

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -15,6 +15,7 @@ import SeverityBadge from '@/components/SeverityBadge'
 import ThemeToggle from '@/components/ThemeToggle'
 import { useToast } from '@/lib/toast'
 import GithubExportModal from '@/components/GithubExportModal'
+import NotionExportModal from '@/components/NotionExportModal'
 
 export default function ResultsPage() {
   const router = useRouter()
@@ -23,6 +24,7 @@ export default function ResultsPage() {
   const [findings, setFindings] = useState<Finding[] | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [showGithubModal, setShowGithubModal] = useState(false)
+  const [showNotionModal, setShowNotionModal] = useState(false)
 
   useEffect(() => {
     const encoded = searchParams.get('r')
@@ -168,6 +170,17 @@ export default function ResultsPage() {
             >
               Email summary
             </a>
+            {findings.length > 0 && (
+              <button
+                onClick={() => setShowNotionModal(true)}
+                className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+              >
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L17.86 1.968c-.42-.326-.981-.7-2.055-.607L3.01 2.295c-.466.046-.56.28-.374.466zm.793 3.08v13.904c0 .747.373 1.027 1.214.98l14.523-.84c.841-.046.935-.56.935-1.167V6.354c0-.606-.233-.933-.748-.887l-15.177.887c-.56.047-.747.327-.747.933zm14.337.745c.093.42 0 .84-.42.888l-.7.14v10.264c-.608.327-1.168.514-1.635.514-.748 0-.935-.234-1.495-.933l-4.577-7.186v6.952L12.21 19s0 .84-1.168.84l-3.222.186c-.093-.186 0-.653.327-.746l.84-.233V9.854L7.822 9.76c-.094-.42.14-1.026.793-1.073l3.456-.233 4.764 7.279v-6.44l-1.215-.14c-.093-.514.28-.887.747-.933zM1.936 1.035l13.31-.98c1.634-.14 2.055-.047 3.082.7l4.249 2.986c.7.513.934.653.934 1.213v16.378c0 1.026-.373 1.634-1.68 1.726l-15.458.934c-.98.047-1.448-.093-1.962-.747l-3.129-4.06c-.56-.747-.793-1.306-.793-1.96V2.667c0-.839.374-1.54 1.447-1.632z" />
+                </svg>
+                Export to Notion
+              </button>
+            )}
             {findings.length > 0 && (
               <button
                 onClick={() => setShowGithubModal(true)}
@@ -351,6 +364,9 @@ export default function ResultsPage() {
 
       {showGithubModal && (
         <GithubExportModal findings={findings} onClose={() => setShowGithubModal(false)} />
+      )}
+      {showNotionModal && (
+        <NotionExportModal findings={findings} onClose={() => setShowNotionModal(false)} />
       )}
     </div>
   )

--- a/components/NotionExportModal.tsx
+++ b/components/NotionExportModal.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useState } from 'react'
+import type { Finding } from '@/types/findings'
+import { createNotionPage } from '@/lib/notion'
+
+interface Props {
+  findings: Finding[]
+  onClose: () => void
+}
+
+export default function NotionExportModal({ findings, onClose }: Props) {
+  const [token, setToken] = useState('')
+  const [databaseId, setDatabaseId] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [pageUrl, setPageUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setPageUrl(null)
+    setLoading(true)
+    try {
+      const url = await createNotionPage(token.trim(), databaseId.trim(), findings)
+      setPageUrl(url)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="w-full max-w-md rounded-2xl border border-[#2a2d3a] bg-[#0e1117] p-6 shadow-xl">
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-white">Export to Notion</h2>
+          <button onClick={onClose} className="text-slate-500 hover:text-white" aria-label="Close">
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {pageUrl ? (
+          <div className="space-y-4">
+            <p className="text-sm text-green-400">Page created successfully.</p>
+            <a
+              href={pageUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block truncate text-sm text-indigo-400 underline"
+            >
+              {pageUrl}
+            </a>
+            <button
+              onClick={onClose}
+              className="w-full rounded-lg bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500"
+            >
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="mb-1 block text-xs text-slate-400" htmlFor="notion-token">
+                Integration token
+              </label>
+              <input
+                id="notion-token"
+                type="password"
+                required
+                value={token}
+                onChange={e => setToken(e.target.value)}
+                placeholder="secret_..."
+                className="w-full rounded-lg border border-[#2a2d3a] bg-[#161922] px-3 py-2 text-sm text-white placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+              <p className="mt-1 text-xs text-slate-600">Never stored — used only for this request.</p>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-slate-400" htmlFor="notion-db">
+                Database ID
+              </label>
+              <input
+                id="notion-db"
+                type="text"
+                required
+                value={databaseId}
+                onChange={e => setDatabaseId(e.target.value)}
+                placeholder="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                className="w-full rounded-lg border border-[#2a2d3a] bg-[#161922] px-3 py-2 text-sm text-white placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+            {error && <p className="text-xs text-red-400">{error}</p>}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full rounded-lg bg-indigo-600 py-2 text-sm font-medium text-white transition hover:bg-indigo-500 disabled:opacity-50"
+            >
+              {loading ? 'Creating page…' : 'Create Notion page'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,0 +1,91 @@
+import type { Finding } from '@/types/findings'
+
+const NOTION_API = 'https://api.notion.com/v1'
+
+export async function createNotionPage(
+  token: string,
+  databaseId: string,
+  findings: Finding[],
+): Promise<string> {
+  const date = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+  const title = `Soroban Guard Scan — ${date}`
+
+  // Build table rows as child blocks
+  const headerRow = {
+    object: 'block',
+    type: 'table_row',
+    table_row: {
+      cells: [
+        [{ type: 'text', text: { content: 'Severity' } }],
+        [{ type: 'text', text: { content: 'Check Name' } }],
+        [{ type: 'text', text: { content: 'Function' } }],
+        [{ type: 'text', text: { content: 'Line' } }],
+        [{ type: 'text', text: { content: 'Description' } }],
+      ],
+    },
+  }
+
+  const rows = findings.map(f => ({
+    object: 'block',
+    type: 'table_row',
+    table_row: {
+      cells: [
+        [{ type: 'text', text: { content: f.severity } }],
+        [{ type: 'text', text: { content: f.check_name } }],
+        [{ type: 'text', text: { content: f.function_name } }],
+        [{ type: 'text', text: { content: String(f.line) } }],
+        [{ type: 'text', text: { content: f.description } }],
+      ],
+    },
+  }))
+
+  const children =
+    findings.length > 0
+      ? [
+          {
+            object: 'block',
+            type: 'table',
+            table: {
+              table_width: 5,
+              has_column_header: true,
+              has_row_header: false,
+              children: [headerRow, ...rows],
+            },
+          },
+        ]
+      : [
+          {
+            object: 'block',
+            type: 'paragraph',
+            paragraph: { rich_text: [{ type: 'text', text: { content: 'No findings detected.' } }] },
+          },
+        ]
+
+  const body = {
+    parent: { database_id: databaseId },
+    properties: {
+      title: {
+        title: [{ type: 'text', text: { content: title } }],
+      },
+    },
+    children,
+  }
+
+  const res = await fetch(`${NOTION_API}/pages`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'Notion-Version': '2022-06-28',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error((err as any).message ?? `Notion API error ${res.status}`)
+  }
+
+  const data = await res.json()
+  return (data as any).url as string
+}


### PR DESCRIPTION
- lib/notion.ts: createNotionPage() calls Notion REST API POST /v1/pages
- components/NotionExportModal.tsx: form with integration token and database ID fields
- app/results/ResultsClient.tsx: 'Export to Notion' button opens modal

Integration token is session-only and never stored. Page title: 'Soroban Guard Scan — {date}'
Each finding is a row in a Notion table with severity, check name, function, line, description columns.

Closes #132

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
