### PR TITLE
feat: add SARIF export for GitHub Code Scanning (#133)

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import type { Finding, Severity } from '@/types/findings'
 import { decodeFindings } from '@/lib/share'
 import { exportEmail } from '@/lib/export'
+import { exportSarif } from '@/lib/sarif'
 import { getAllScanHistory } from '@/lib/history'
 import { diffFindings } from '@/lib/diffFindings'
 import FindingsTable from '@/components/FindingsTable'
@@ -102,6 +103,19 @@ export default function ResultsPage() {
     setMuteRefresh(prev => prev + 1)
   }
 
+  function handleDownloadSarif() {
+    const content = exportSarif(findings ?? [])
+    const blob = new Blob([content], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'soroban-guard.sarif'
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+  }
+
   if (findings === null) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -168,6 +182,12 @@ export default function ResultsPage() {
             >
               Email summary
             </a>
+            <button
+              onClick={handleDownloadSarif}
+              className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+            >
+              Download SARIF
+            </button>
             {findings.length > 0 && (
               <button
                 onClick={() => setShowGithubModal(true)}

--- a/lib/sarif.ts
+++ b/lib/sarif.ts
@@ -1,0 +1,58 @@
+import type { Finding, Severity } from '@/types/findings'
+
+const LEVEL_MAP: Record<Severity, 'error' | 'warning' | 'note'> = {
+  Critical: 'error',
+  High: 'error',
+  Medium: 'warning',
+  Low: 'note',
+}
+
+export function exportSarif(findings: Finding[]): string {
+  const ruleIds = new Set<string>()
+  const rules = findings
+    .filter(f => { if (ruleIds.has(f.check_name)) return false; ruleIds.add(f.check_name); return true })
+    .map(f => ({
+    id: f.check_name,
+    name: f.check_name,
+    shortDescription: { text: f.check_name },
+    fullDescription: { text: f.description },
+    defaultConfiguration: { level: LEVEL_MAP[f.severity as Severity] },
+  }))
+
+  const results = findings.map(f => ({
+    ruleId: f.check_name,
+    level: LEVEL_MAP[f.severity as Severity],
+    message: { text: f.description },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: { uri: f.file_path, uriBaseId: '%SRCROOT%' },
+          region: { startLine: f.line },
+        },
+        logicalLocations: [
+          { name: f.function_name, kind: 'function' },
+        ],
+      },
+    ],
+  }))
+
+  const sarif = {
+    $schema: 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
+    version: '2.1.0',
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: 'Soroban Guard',
+            version: '1.0.0',
+            informationUri: 'https://soroban-guard.vercel.app',
+            rules,
+          },
+        },
+        results,
+      },
+    ],
+  }
+
+  return JSON.stringify(sarif, null, 2)
+}


### PR DESCRIPTION
- lib/sarif.ts: exportSarif(findings) generates valid SARIF 2.1.0 JSON
- app/results/ResultsClient.tsx: 'Download SARIF' button downloads soroban-guard.sarif

Severity mapping: Critical/High=error, Medium=warning, Low=note Empty findings produce a valid SARIF with zero results.

Closes #133

