### PR TITLE
feat: PDF report generation for scan findings (#131)

### DIFF
--- a/app/report/page.tsx
+++ b/app/report/page.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import type { Finding, Severity } from '@/types/findings'
+
+const SEVERITY_ORDER: Record<Severity, number> = { Critical: 0, High: 1, Medium: 2, Low: 3 }
+const SEVERITY_COLOR: Record<Severity, string> = {
+  Critical: '#f43f5e',
+  High: '#ef4444',
+  Medium: '#f59e0b',
+  Low: '#38bdf8',
+}
+
+export default function ReportPage() {
+  const searchParams = useSearchParams()
+  const [findings, setFindings] = useState<Finding[]>([])
+  const [source, setSource] = useState('')
+  const [scannedAt, setScannedAt] = useState('')
+  const [score, setScore] = useState(100)
+
+  useEffect(() => {
+    try {
+      const f = searchParams.get('f')
+      if (f) setFindings(JSON.parse(atob(f)) as Finding[])
+      setSource(searchParams.get('source') ?? 'Unknown')
+      setScannedAt(searchParams.get('scannedAt') ?? new Date().toISOString())
+      setScore(Number(searchParams.get('score') ?? 100))
+    } catch {
+      // ignore parse errors
+    }
+  }, [searchParams])
+
+  useEffect(() => {
+    if (findings.length >= 0 && source) {
+      setTimeout(() => window.print(), 400)
+    }
+  }, [findings, source])
+
+  const counts: Record<Severity, number> = { Critical: 0, High: 0, Medium: 0, Low: 0 }
+  for (const f of findings) counts[f.severity as Severity]++
+
+  const sorted = [...findings].sort((a, b) => SEVERITY_ORDER[a.severity as Severity] - SEVERITY_ORDER[b.severity as Severity])
+
+  const date = scannedAt ? new Date(scannedAt).toLocaleString() : ''
+
+  return (
+    <>
+      <style>{`
+        @media print {
+          @page { margin: 20mm; }
+          .no-print { display: none !important; }
+          body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+        }
+        body { font-family: system-ui, sans-serif; background: #fff; color: #111; margin: 0; }
+        .page { max-width: 900px; margin: 0 auto; padding: 40px 32px; }
+        .cover { border-bottom: 2px solid #e5e7eb; padding-bottom: 32px; margin-bottom: 32px; }
+        .cover h1 { font-size: 28px; font-weight: 700; margin: 0 0 8px; }
+        .cover p { color: #6b7280; margin: 4px 0; font-size: 14px; }
+        .score-badge { display: inline-block; padding: 4px 14px; border-radius: 999px; font-weight: 700; font-size: 18px; margin-top: 12px; }
+        .summary { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 32px; }
+        .summary-card { border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px; text-align: center; }
+        .summary-card .label { font-size: 12px; color: #6b7280; margin-bottom: 4px; }
+        .summary-card .value { font-size: 28px; font-weight: 700; }
+        table { width: 100%; border-collapse: collapse; font-size: 13px; }
+        th { background: #f9fafb; text-align: left; padding: 8px 12px; border-bottom: 2px solid #e5e7eb; font-weight: 600; }
+        td { padding: 8px 12px; border-bottom: 1px solid #f3f4f6; vertical-align: top; }
+        tr:nth-child(even) td { background: #fafafa; }
+        .sev { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 700; color: #fff; }
+        h2 { font-size: 18px; font-weight: 600; margin: 0 0 16px; }
+      `}</style>
+
+      <div className="page">
+        {/* Cover */}
+        <div className="cover">
+          <h1>Soroban Guard — Security Report</h1>
+          <p>Contract: {source}</p>
+          <p>Scanned: {date}</p>
+          <div
+            className="score-badge"
+            style={{ background: score >= 80 ? '#dcfce7' : score >= 50 ? '#fef9c3' : '#fee2e2', color: score >= 80 ? '#166534' : score >= 50 ? '#854d0e' : '#991b1b' }}
+          >
+            Security Score: {score}
+          </div>
+        </div>
+
+        {/* Summary */}
+        <h2>Summary</h2>
+        <div className="summary">
+          {(['Critical', 'High', 'Medium', 'Low'] as Severity[]).map(s => (
+            <div key={s} className="summary-card">
+              <div className="label">{s}</div>
+              <div className="value" style={{ color: SEVERITY_COLOR[s] }}>{counts[s]}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Findings table */}
+        <h2>Findings ({findings.length})</h2>
+        {findings.length === 0 ? (
+          <p style={{ color: '#6b7280', fontSize: 14 }}>No findings detected.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>Severity</th>
+                <th>Check</th>
+                <th>Function</th>
+                <th>File</th>
+                <th>Line</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((f, i) => (
+                <tr key={i}>
+                  <td>
+                    <span className="sev" style={{ background: SEVERITY_COLOR[f.severity as Severity] }}>
+                      {f.severity}
+                    </span>
+                  </td>
+                  <td>{f.check_name}</td>
+                  <td>{f.function_name}</td>
+                  <td style={{ wordBreak: 'break-all' }}>{f.file_path}</td>
+                  <td>{f.line}</td>
+                  <td>{f.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        <p style={{ marginTop: 40, fontSize: 12, color: '#9ca3af', borderTop: '1px solid #e5e7eb', paddingTop: 16 }}>
+          Generated by Soroban Guard · Veritas Vaults Network
+        </p>
+      </div>
+    </>
+  )
+}

--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import type { Finding, Severity } from '@/types/findings'
 import { decodeFindings } from '@/lib/share'
 import { exportEmail } from '@/lib/export'
+import { generatePdfReport } from '@/lib/pdfReport'
 import { getAllScanHistory } from '@/lib/history'
 import { diffFindings } from '@/lib/diffFindings'
 import FindingsTable from '@/components/FindingsTable'
@@ -102,6 +103,16 @@ export default function ResultsPage() {
     setMuteRefresh(prev => prev + 1)
   }
 
+  function handleDownloadPdf() {
+    if (!findings) return
+    const source = sessionStorage.getItem('sg_last_scan_source') ?? sessionStorage.getItem('sg_scan_source') ?? 'Unknown'
+    generatePdfReport(findings, {
+      source,
+      scannedAt: new Date().toISOString(),
+      score: calculateScore(findings),
+    })
+  }
+
   if (findings === null) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -168,6 +179,12 @@ export default function ResultsPage() {
             >
               Email summary
             </a>
+            <button
+              onClick={handleDownloadPdf}
+              className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+            >
+              Download PDF
+            </button>
             {findings.length > 0 && (
               <button
                 onClick={() => setShowGithubModal(true)}

--- a/lib/pdfReport.ts
+++ b/lib/pdfReport.ts
@@ -1,0 +1,17 @@
+import type { Finding } from '@/types/findings'
+
+export interface ReportMetadata {
+  source: string
+  scannedAt: string
+  score: number
+}
+
+export function generatePdfReport(findings: Finding[], metadata: ReportMetadata): void {
+  const params = new URLSearchParams({
+    f: btoa(JSON.stringify(findings)),
+    source: metadata.source,
+    scannedAt: metadata.scannedAt,
+    score: String(metadata.score),
+  })
+  window.open(`/report?${params.toString()}`, '_blank')
+}


### PR DESCRIPTION
- lib/pdfReport.ts: generatePdfReport() opens /report page in new tab and triggers window.print()
- app/report/page.tsx: print-optimised page with cover, summary cards, and full findings table; auto-triggers print on load
- app/results/ResultsClient.tsx: 'Download PDF' button navigates to /report with findings encoded in URL

Print stylesheet hides browser UI elements.
Report includes cover page with scan date and score, all findings with full details. Readable in both colour and black-and-white.

Closes #131

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
