### PR TITLE
feat: scheduled rescans for saved contract IDs (#122)

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -6,6 +6,12 @@ import type { Finding } from '@/types/findings'
 import ConfirmModal from '@/components/ConfirmModal'
 import SeverityTrendChart from '@/components/SeverityTrendChart'
 import ScanHeatmap from '@/components/ScanHeatmap'
+import {
+  addSchedule,
+  removeSchedule,
+  getSchedule,
+  type ScheduleInterval,
+} from '@/lib/schedule'
 
 interface HistoryEntry {
   id: string
@@ -28,15 +34,35 @@ export default function HistoryPage() {
   const router = useRouter()
   const [entries, setEntries] = useState<HistoryEntry[]>([])
   const [showConfirm, setShowConfirm] = useState(false)
+  // Track schedule state per entry id
+  const [schedules, setSchedules] = useState<Record<string, ScheduleInterval | null>>({})
 
   useEffect(() => {
-    setEntries(loadHistory())
+    const loaded = loadHistory()
+    setEntries(loaded)
+    // Load existing schedules for each entry
+    const initial: Record<string, ScheduleInterval | null> = {}
+    for (const e of loaded) {
+      const s = getSchedule(e.source, 'testnet')
+      initial[e.id] = s?.interval ?? null
+    }
+    setSchedules(initial)
   }, [])
 
   function clearHistory() {
     localStorage.removeItem(STORAGE_KEY)
     setEntries([])
     setShowConfirm(false)
+  }
+
+  function handleScheduleChange(entry: HistoryEntry, interval: ScheduleInterval | 'never') {
+    if (interval === 'never') {
+      removeSchedule(entry.source, 'testnet')
+      setSchedules(prev => ({ ...prev, [entry.id]: null }))
+    } else {
+      addSchedule(entry.source, 'testnet', interval)
+      setSchedules(prev => ({ ...prev, [entry.id]: interval }))
+    }
   }
 
   return (
@@ -75,23 +101,43 @@ export default function HistoryPage() {
             </div>
           )}
           <ul className="space-y-3">
-          {entries.map(e => (
-            <li
-              key={e.id}
-              className="rounded-xl border border-[#2a2d3a] bg-[#12151f] px-5 py-4"
-            >
-              <div className="flex items-center justify-between">
-                <span className="truncate font-mono text-sm text-slate-300">{e.source}</span>
-                <span className="ml-4 shrink-0 text-xs text-slate-500">
-                  {new Date(e.date).toLocaleDateString()}
-                </span>
-              </div>
-              <p className="mt-1 text-xs text-slate-500">
-                {e.findings.length} finding{e.findings.length !== 1 ? 's' : ''}
-              </p>
-            </li>
-          ))}
-        </ul>
+            {entries.map(e => (
+              <li
+                key={e.id}
+                className="rounded-xl border border-[#2a2d3a] bg-[#12151f] px-5 py-4"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="truncate font-mono text-sm text-slate-300">{e.source}</span>
+                  <span className="ml-4 shrink-0 text-xs text-slate-500">
+                    {new Date(e.date).toLocaleDateString()}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-slate-500">
+                  {e.findings.length} finding{e.findings.length !== 1 ? 's' : ''}
+                </p>
+                {/* Schedule rescan toggle */}
+                <div className="mt-3 flex items-center gap-2">
+                  <svg className="h-3.5 w-3.5 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <span className="text-xs text-slate-500">Rescan:</span>
+                  {(['never', 'daily', 'weekly'] as const).map(opt => (
+                    <button
+                      key={opt}
+                      onClick={() => handleScheduleChange(e, opt)}
+                      className={`rounded-md px-2 py-0.5 text-xs font-medium transition ${
+                        (opt === 'never' && !schedules[e.id]) || schedules[e.id] === opt
+                          ? 'bg-indigo-500/20 text-indigo-300'
+                          : 'text-slate-500 hover:text-slate-300'
+                      }`}
+                    >
+                      {opt.charAt(0).toUpperCase() + opt.slice(1)}
+                    </button>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ul>
         </>
       )}
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,9 @@ import { NETWORKS } from '@/types/stellar'
 import { addRecord } from '@/lib/history'
 import { saveSourceCode } from '@/lib/codeStore'
 import { notify } from '@/lib/notifications'
+import { getDueScans, markRan } from '@/lib/schedule'
+import { addScanRecord } from '@/lib/history'
+import { useToast } from '@/lib/toast'
 import { FEATURED_CONTRACTS } from '@/lib/featuredContracts'
 import ScanQuotaIndicator from '@/components/ScanQuota'
 
@@ -35,6 +38,7 @@ export default function Page() {
 function HomePage() {
   const router = useRouter()
   const { publicKey: walletKey, network: walletNetwork } = useWallet()
+  const { show } = useToast()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [networkHealthy, setNetworkHealthy] = useState(true)
@@ -44,6 +48,28 @@ function HomePage() {
   const [quota, setQuota] = useState<ScanQuota | null>(null)
 
   const activeNetwork = walletKey ? walletNetwork : manualNetwork
+
+  // Run overdue scheduled scans on page load
+  useEffect(() => {
+    const due = getDueScans()
+    if (due.length === 0) return
+    ;(async () => {
+      for (const s of due) {
+        try {
+          const { NETWORKS } = await import('@/types/stellar')
+          const net = NETWORKS[s.network] ?? NETWORKS.testnet
+          const data = await scanContract(s.contractId, net)
+          markRan(s.contractId, s.network)
+          addScanRecord('scheduled', s.contractId, s.network, data.findings)
+          show(`Scheduled rescan of ${s.contractId.slice(0, 8)}… complete — ${data.findings.length} finding${data.findings.length !== 1 ? 's' : ''}`, 'success')
+          notify('Scheduled rescan complete', `${data.findings.length} finding${data.findings.length !== 1 ? 's' : ''} for ${s.contractId.slice(0, 8)}…`)
+        } catch {
+          // Silently skip failed scheduled scans
+        }
+      }
+    })()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   async function handleScan(source: string, mode: 'code' | 'github' | 'contractId' | 'ipfs' = 'code') {
     setLoading(true)

--- a/lib/schedule.ts
+++ b/lib/schedule.ts
@@ -1,0 +1,71 @@
+const STORAGE_KEY = 'sg_scheduled_scans'
+
+export type ScheduleInterval = 'daily' | 'weekly'
+
+export interface ScheduledScan {
+  contractId: string
+  network: string
+  interval: ScheduleInterval
+  lastRun: string | null // ISO string
+}
+
+function load(): ScheduledScan[] {
+  if (typeof window === 'undefined') return []
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
+  } catch {
+    return []
+  }
+}
+
+function save(schedules: ScheduledScan[]): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(schedules))
+  } catch {
+    // Silently fail
+  }
+}
+
+export function addSchedule(contractId: string, network: string, interval: ScheduleInterval): void {
+  const schedules = load()
+  const existing = schedules.findIndex(s => s.contractId === contractId && s.network === network)
+  if (existing >= 0) {
+    schedules[existing].interval = interval
+  } else {
+    schedules.push({ contractId, network, interval, lastRun: null })
+  }
+  save(schedules)
+}
+
+export function removeSchedule(contractId: string, network: string): void {
+  const schedules = load().filter(s => !(s.contractId === contractId && s.network === network))
+  save(schedules)
+}
+
+export function getSchedule(contractId: string, network: string): ScheduledScan | null {
+  return load().find(s => s.contractId === contractId && s.network === network) ?? null
+}
+
+export function getAllSchedules(): ScheduledScan[] {
+  return load()
+}
+
+export function markRan(contractId: string, network: string): void {
+  const schedules = load()
+  const entry = schedules.find(s => s.contractId === contractId && s.network === network)
+  if (entry) {
+    entry.lastRun = new Date().toISOString()
+    save(schedules)
+  }
+}
+
+export function getDueScans(): ScheduledScan[] {
+  const now = Date.now()
+  return load().filter(s => {
+    if (!s.lastRun) return true
+    const last = new Date(s.lastRun).getTime()
+    const intervalMs = s.interval === 'daily' ? 86_400_000 : 7 * 86_400_000
+    return now - last >= intervalMs
+  })
+}


### PR DESCRIPTION
- Add lib/schedule.ts with addSchedule, removeSchedule, getDueScans, markRan
- Add interval options (Daily/Weekly/Never) per history record in app/history/page.tsx
- Auto-trigger due scans on page load in app/page.tsx with toast notification

Closes #122

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
