### PR TITLE
feat: findings word cloud panel (#121)

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -15,6 +15,7 @@ import SeverityBadge from '@/components/SeverityBadge'
 import ThemeToggle from '@/components/ThemeToggle'
 import { useToast } from '@/lib/toast'
 import GithubExportModal from '@/components/GithubExportModal'
+import FindingsWordCloud from '@/components/FindingsWordCloud'
 
 export default function ResultsPage() {
   const router = useRouter()
@@ -23,6 +24,7 @@ export default function ResultsPage() {
   const [findings, setFindings] = useState<Finding[] | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [showGithubModal, setShowGithubModal] = useState(false)
+  const [showWordCloud, setShowWordCloud] = useState(false)
 
   useEffect(() => {
     const encoded = searchParams.get('r')
@@ -255,8 +257,37 @@ export default function ResultsPage() {
           <EmptyState onScanAnother={handleScanAnother} />
         ) : (
           <div>
-            <div className="mb-3 flex items-center justify-between">
-              <h2 className="text-sm font-semibold text-slate-400">
+            {/* Word cloud collapsible panel */}
+            <div className="mb-6">
+              <button
+                onClick={() => setShowWordCloud(v => !v)}
+                className="flex w-full items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-5 py-3 text-sm font-medium text-slate-300 transition hover:bg-[var(--bg-hover)]"
+                aria-expanded={showWordCloud}
+              >
+                <span className="flex items-center gap-2">
+                  <svg className="h-4 w-4 text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+                  </svg>
+                  Vulnerability themes
+                </span>
+                <svg
+                  className={`h-4 w-4 text-slate-500 transition-transform duration-200 ${showWordCloud ? 'rotate-180' : ''}`}
+                  fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {showWordCloud && (
+                <div className="mt-2">
+                  <FindingsWordCloud
+                    findings={findings}
+                    onTermClick={term => setSearchQuery(term)}
+                  />
+                </div>
+              )}
+            </div>
+
+            <div className="mb-3 flex items-center justify-between">              <h2 className="text-sm font-semibold text-slate-400">
                 Findings — click a row to expand details
               </h2>
               <div className="flex items-center gap-2">

--- a/components/FindingsWordCloud.tsx
+++ b/components/FindingsWordCloud.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { Finding } from '@/types/findings'
+import { extractTerms } from '@/lib/wordCloud'
+
+interface Props {
+  findings: Finding[]
+  onTermClick?: (term: string) => void
+}
+
+const COLORS = [
+  '#818cf8', // indigo-400
+  '#a78bfa', // violet-400
+  '#60a5fa', // blue-400
+  '#34d399', // emerald-400
+  '#fb923c', // orange-400
+  '#f472b6', // pink-400
+  '#38bdf8', // sky-400
+]
+
+export default function FindingsWordCloud({ findings, onTermClick }: Props) {
+  const terms = useMemo(() => extractTerms(findings), [findings])
+  const entries = Object.entries(terms)
+
+  if (entries.length === 0) return null
+
+  const maxFreq = entries[0][1]
+  const minFreq = entries[entries.length - 1][1]
+  const range = maxFreq - minFreq || 1
+
+  // Font size: 12px (min) to 36px (max)
+  function fontSize(freq: number): number {
+    return Math.round(12 + ((freq - minFreq) / range) * 24)
+  }
+
+  // Lay out words in a simple wrapping flex layout
+  return (
+    <div
+      className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-6 py-5"
+      role="list"
+      aria-label="Findings word cloud"
+    >
+      {entries.map(([term, freq], i) => (
+        <button
+          key={term}
+          role="listitem"
+          onClick={() => onTermClick?.(term)}
+          title={`${term} (${freq})`}
+          style={{
+            fontSize: `${fontSize(freq)}px`,
+            color: COLORS[i % COLORS.length],
+            lineHeight: 1.2,
+          }}
+          className="cursor-pointer rounded px-1 font-semibold transition-opacity hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        >
+          {term}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/lib/wordCloud.ts
+++ b/lib/wordCloud.ts
@@ -1,0 +1,48 @@
+import type { Finding } from '@/types/findings'
+
+const STOP_WORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+  'of', 'with', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been',
+  'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
+  'could', 'should', 'may', 'might', 'can', 'not', 'no', 'nor', 'so',
+  'yet', 'both', 'either', 'neither', 'each', 'few', 'more', 'most',
+  'other', 'some', 'such', 'than', 'too', 'very', 'just', 'that', 'this',
+  'it', 'its', 'as', 'if', 'into', 'through', 'during', 'before', 'after',
+  'above', 'below', 'between', 'out', 'off', 'over', 'under', 'again',
+  'then', 'once', 'here', 'there', 'when', 'where', 'why', 'how', 'all',
+  'any', 'which', 'who', 'whom', 'what', 'without', 'about', 'against',
+  'up', 'down', 'while', 'also', 'only', 'same', 'own', 'your', 'their',
+])
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, ' ')
+    .split(/\s+/)
+    .filter(t => t.length > 2 && !STOP_WORDS.has(t))
+}
+
+/**
+ * Extract term frequencies from findings' check_name and description fields.
+ * Returns a map of term → count, sorted by frequency descending, top 30.
+ */
+export function extractTerms(findings: Finding[]): Record<string, number> {
+  const freq: Record<string, number> = {}
+
+  for (const f of findings) {
+    // Weight check_name tokens more (×3) since they're more signal-dense
+    for (const token of tokenize(f.check_name)) {
+      freq[token] = (freq[token] ?? 0) + 3
+    }
+    for (const token of tokenize(f.description)) {
+      freq[token] = (freq[token] ?? 0) + 1
+    }
+  }
+
+  // Sort by frequency and return top 30
+  return Object.fromEntries(
+    Object.entries(freq)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 30),
+  )
+}


### PR DESCRIPTION
- Add lib/wordCloud.ts with extractTerms() that tokenises check_name (×3 weight) and description, removes stop words, returns top 30 terms
- Add components/FindingsWordCloud.tsx SVG-free word cloud with font size proportional to frequency; clicking a term filters the findings table
- Add collapsible 'Vulnerability themes' panel in ResultsClient.tsx, collapsed by default

Closes #121

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
