### PR TITLE
feat: GitHub Gist URL input mode (#120)

### DIFF
--- a/components/ScanInput.tsx
+++ b/components/ScanInput.tsx
@@ -5,10 +5,11 @@ import { SAMPLE_CONTRACT } from '@/lib/sampleContract'
 import { isValidCid, fetchFromIpfs } from '@/lib/ipfs'
 import { requestPermission } from '@/lib/notifications'
 import { extractContractIdFromUrl } from '@/lib/stellar'
+import { isValidGistUrl, fetchGistFiles, fetchGistFileContent, type GistFile } from '@/lib/gist'
 
 const NOTIF_PREF_KEY = 'sg_notifications_enabled'
 
-type InputMode = 'code' | 'github' | 'contractId' | 'ipfs'
+type InputMode = 'code' | 'github' | 'contractId' | 'ipfs' | 'gist'
 
 interface Props {
   onScan: (source: string, mode: InputMode) => void
@@ -42,6 +43,13 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
   const [ipfsError, setIpfsError] = useState<string | null>(null)
   const [normalized, setNormalized] = useState(false)
   const [extractedFromUrl, setExtractedFromUrl] = useState(false)
+  // Gist state
+  const [gistUrl, setGistUrl] = useState('')
+  const [gistFiles, setGistFiles] = useState<GistFile[]>([])
+  const [gistSelectedFile, setGistSelectedFile] = useState<string>('')
+  const [gistContent, setGistContent] = useState<string | null>(null)
+  const [gistFetching, setGistFetching] = useState(false)
+  const [gistError, setGistError] = useState<string | null>(null)
   const [notificationsEnabled, setNotificationsEnabled] = useState(() => {
     if (typeof window === 'undefined') return false
     return localStorage.getItem(NOTIF_PREF_KEY) === 'true'
@@ -94,6 +102,48 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
     }
   }
 
+  async function handleFetchGist() {
+    if (!isValidGistUrl(gistUrl)) {
+      setGistError('Invalid Gist URL. Expected: https://gist.github.com/{user}/{id}')
+      return
+    }
+    setGistFetching(true)
+    setGistError(null)
+    setGistContent(null)
+    setGistFiles([])
+    setGistSelectedFile('')
+    try {
+      const data = await fetchGistFiles(gistUrl)
+      setGistFiles(data.files)
+      if (data.files.length === 1) {
+        const content = await fetchGistFileContent(data.files[0].raw_url)
+        setGistContent(content)
+        setGistSelectedFile(data.files[0].filename)
+      } else if (data.files.length > 1) {
+        setGistSelectedFile(data.files[0].filename)
+      }
+    } catch (err) {
+      setGistError(err instanceof Error ? err.message : 'Failed to fetch Gist')
+    } finally {
+      setGistFetching(false)
+    }
+  }
+
+  async function handleGistFileSelect(filename: string) {
+    setGistSelectedFile(filename)
+    const file = gistFiles.find(f => f.filename === filename)
+    if (!file) return
+    setGistFetching(true)
+    try {
+      const content = await fetchGistFileContent(file.raw_url)
+      setGistContent(content)
+    } catch (err) {
+      setGistError(err instanceof Error ? err.message : 'Failed to fetch file')
+    } finally {
+      setGistFetching(false)
+    }
+  }
+
   async function toggleNotifications() {
     if (!notificationsEnabled) {
       const granted = await requestPermission()
@@ -110,6 +160,10 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
     e.preventDefault()
     if (mode === 'ipfs') {
       if (ipfsPreview) onScan(ipfsPreview, mode)
+      return
+    }
+    if (mode === 'gist') {
+      if (gistContent) onScan(gistContent, 'code')
       return
     }
     const source =
@@ -140,7 +194,9 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
         ? repoUrl.trim().length > 0 && repoValidation.valid
         : mode === 'contractId'
           ? contractId.trim().length > 0 && contractValid
-          : ipfsPreview !== null)
+          : mode === 'gist'
+            ? gistContent !== null
+            : ipfsPreview !== null)
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -189,6 +245,17 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
           }
         >
           IPFS CID
+        </TabButton>
+        <TabButton
+          active={mode === 'gist'}
+          onClick={() => setMode('gist')}
+          icon={
+            <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+            </svg>
+          }
+        >
+          Gist URL
         </TabButton>
       </div>
 
@@ -267,7 +334,7 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
             will fetch the WASM bytecode via Soroban RPC and analyze it.
           </p>
         </div>
-      ) : (
+      ) : mode === 'ipfs' ? (
         <div className="space-y-2">
           <div className="flex gap-2">
             <input
@@ -313,6 +380,75 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
               <textarea
                 readOnly
                 value={ipfsPreview}
+                rows={10}
+                className="code-textarea w-full resize-y rounded-xl border border-emerald-500/30 bg-[#12151f] px-4 py-3 text-sm text-slate-400 outline-none"
+                spellCheck={false}
+              />
+            </div>
+          )}
+        </div>
+      ) : (
+        /* Gist URL mode */
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <input
+              type="url"
+              value={gistUrl}
+              onChange={e => { setGistUrl(e.target.value); setGistError(null); setGistContent(null); setGistFiles([]) }}
+              onKeyDown={handleKeyDown}
+              placeholder="https://gist.github.com/user/abc123"
+              className="flex-1 rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 text-slate-300 placeholder-slate-600 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
+              disabled={loading || gistFetching}
+            />
+            <button
+              type="button"
+              onClick={handleFetchGist}
+              disabled={!gistUrl.trim() || gistFetching || loading}
+              className="flex items-center gap-1.5 rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 text-sm text-slate-300 transition hover:border-indigo-500/50 hover:text-indigo-300 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {gistFetching ? (
+                <svg className="spinner h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                  <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
+                </svg>
+              ) : (
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+                </svg>
+              )}
+              Fetch
+            </button>
+          </div>
+          {gistError && <p className="text-xs text-rose-400">{gistError}</p>}
+          {!gistError && gistFiles.length === 0 && (
+            <p className="text-xs text-slate-500">
+              Paste a public Gist URL to fetch and scan its Rust source.
+            </p>
+          )}
+          {/* Multi-file selector */}
+          {gistFiles.length > 1 && (
+            <div className="space-y-1">
+              <label htmlFor="gist-file-select" className="text-xs text-slate-500">Select file:</label>
+              <select
+                id="gist-file-select"
+                value={gistSelectedFile}
+                onChange={e => handleGistFileSelect(e.target.value)}
+                className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 outline-none focus:border-indigo-500/60"
+                disabled={gistFetching}
+              >
+                {gistFiles.map(f => (
+                  <option key={f.filename} value={f.filename}>{f.filename}</option>
+                ))}
+              </select>
+            </div>
+          )}
+          {gistContent !== null && (
+            <div className="space-y-1">
+              <p className="text-xs text-emerald-400">
+                ✓ Fetched {gistContent.length.toLocaleString()} chars — preview below
+              </p>
+              <textarea
+                readOnly
+                value={gistContent}
                 rows={10}
                 className="code-textarea w-full resize-y rounded-xl border border-emerald-500/30 bg-[#12151f] px-4 py-3 text-sm text-slate-400 outline-none"
                 spellCheck={false}

--- a/lib/gist.ts
+++ b/lib/gist.ts
@@ -1,0 +1,54 @@
+const GIST_URL_RE = /^https:\/\/gist\.github\.com\/([^/]+)\/([a-f0-9]+)\/?$/i
+
+export interface GistFile {
+  filename: string
+  language: string | null
+  raw_url: string
+  content?: string
+}
+
+export function isValidGistUrl(url: string): boolean {
+  return GIST_URL_RE.test(url.trim())
+}
+
+export interface GistData {
+  id: string
+  files: GistFile[]
+}
+
+/**
+ * Fetch gist metadata and file list from the GitHub Gist API.
+ * Returns the list of files with their raw_url for content fetching.
+ */
+export async function fetchGistFiles(url: string): Promise<GistData> {
+  const match = url.trim().match(GIST_URL_RE)
+  if (!match) throw new Error('Invalid Gist URL. Expected: https://gist.github.com/{user}/{id}')
+
+  const gistId = match[2]
+  const apiUrl = `https://api.github.com/gists/${gistId}`
+
+  const res = await fetch(apiUrl, {
+    headers: { Accept: 'application/vnd.github+json' },
+  })
+
+  if (res.status === 404) throw new Error('Gist not found. Make sure it is public.')
+  if (!res.ok) throw new Error(`GitHub API error ${res.status}`)
+
+  const data = await res.json()
+  const files: GistFile[] = Object.values(data.files as Record<string, any>).map(f => ({
+    filename: f.filename,
+    language: f.language ?? null,
+    raw_url: f.raw_url,
+  }))
+
+  return { id: gistId, files }
+}
+
+/**
+ * Fetch the raw content of a single gist file.
+ */
+export async function fetchGistFileContent(rawUrl: string): Promise<string> {
+  const res = await fetch(rawUrl)
+  if (!res.ok) throw new Error(`Failed to fetch gist file: ${res.status}`)
+  return res.text()
+}


### PR DESCRIPTION
- Add lib/gist.ts with isValidGistUrl, fetchGistFiles, fetchGistFileContent
- Validate URL matches https://gist.github.com/{user}/{id} before fetching
- Add 'Gist URL' tab to ScanInput alongside existing tabs
- Show file selector dropdown for multi-file Gists
- Preview fetched content before submitting; pass as source code to scan API
- Show inline error for invalid URLs or fetch failures

Closes #120

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
