### PR TITLE
feat: add embeddable security status widget and embed code button (#136)

### DIFF
--- a/app/embed/[token]/page.tsx
+++ b/app/embed/[token]/page.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from 'next'
+import { decodeFindings } from '@/lib/share'
+import type { Finding } from '@/types/findings'
+
+interface Props {
+  params: { token: string }
+}
+
+export const metadata: Metadata = {
+  title: 'Soroban Guard — Security Status',
+}
+
+function score(findings: Finding[]): number {
+  if (findings.length === 0) return 100
+  const weights: Record<string, number> = { Critical: 25, High: 15, Medium: 7, Low: 2 }
+  const deduction = findings.reduce((sum, f) => sum + (weights[f.severity] ?? 0), 0)
+  return Math.max(0, 100 - deduction)
+}
+
+export default function EmbedPage({ params }: Props) {
+  const findings = decodeFindings(params.token)
+  const counts = { Critical: 0, High: 0, Medium: 0, Low: 0 }
+  for (const f of findings) {
+    if (f.severity in counts) counts[f.severity as keyof typeof counts]++
+  }
+  const s = score(findings)
+  const scoreColor = s >= 80 ? '#22c55e' : s >= 50 ? '#f59e0b' : '#ef4444'
+  const scanDate = new Date().toLocaleDateString()
+
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, padding: 0, background: '#0d0f17', fontFamily: 'system-ui, sans-serif' }}>
+        <div style={{
+          width: 300,
+          height: 150,
+          background: 'linear-gradient(135deg, #12151f 0%, #1a1d27 100%)',
+          border: '1px solid #2a2d3a',
+          borderRadius: 12,
+          padding: '12px 16px',
+          boxSizing: 'border-box',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          overflow: 'hidden',
+        }}>
+          {/* Header */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <div style={{ width: 20, height: 20, background: '#4f46e5', borderRadius: 5, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="white" strokeWidth={2.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                </svg>
+              </div>
+              <span style={{ color: '#e2e8f0', fontSize: 11, fontWeight: 600 }}>Soroban Guard</span>
+            </div>
+            <span style={{ color: scoreColor, fontSize: 22, fontWeight: 800 }}>{s}</span>
+          </div>
+
+          {/* Counts */}
+          <div style={{ display: 'flex', gap: 6 }}>
+            {(['High', 'Medium', 'Low'] as const).map(sev => {
+              const colors: Record<string, string> = { High: '#ef4444', Medium: '#f59e0b', Low: '#38bdf8' }
+              return (
+                <div key={sev} style={{
+                  flex: 1,
+                  background: 'rgba(255,255,255,0.04)',
+                  borderRadius: 6,
+                  padding: '4px 6px',
+                  textAlign: 'center',
+                }}>
+                  <div style={{ color: colors[sev], fontSize: 14, fontWeight: 700 }}>{counts[sev]}</div>
+                  <div style={{ color: '#64748b', fontSize: 9, marginTop: 1 }}>{sev}</div>
+                </div>
+              )
+            })}
+          </div>
+
+          {/* Footer */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <span style={{ color: '#475569', fontSize: 9 }}>Scanned {scanDate}</span>
+            <a
+              href="https://github.com/Veritas-Vaults-Network/soroban-guard-web"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: '#6366f1', fontSize: 9, textDecoration: 'none' }}
+            >
+              Powered by Soroban Guard
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -15,6 +15,7 @@ import SeverityBadge from '@/components/SeverityBadge'
 import ThemeToggle from '@/components/ThemeToggle'
 import { useToast } from '@/lib/toast'
 import GithubExportModal from '@/components/GithubExportModal'
+import { exportJson, exportCsv, downloadMarkdown } from '@/lib/export'
 
 export default function ResultsPage() {
   const router = useRouter()
@@ -23,6 +24,8 @@ export default function ResultsPage() {
   const [findings, setFindings] = useState<Finding[] | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [showGithubModal, setShowGithubModal] = useState(false)
+  const [showEmbedModal, setShowEmbedModal] = useState(false)
+  const [embedCopied, setEmbedCopied] = useState(false)
 
   useEffect(() => {
     const encoded = searchParams.get('r')
@@ -76,6 +79,22 @@ export default function ResultsPage() {
     const url = window.location.href
     navigator.clipboard.writeText(url)
     show('Link copied!', 'success')
+  }
+
+  function getEmbedToken(): string {
+    return searchParams.get('r') ?? ''
+  }
+
+  function getEmbedSnippet(): string {
+    const token = getEmbedToken()
+    const origin = typeof window !== 'undefined' ? window.location.origin : ''
+    return `<iframe src="${origin}/embed/${token}" width="300" height="150" frameborder="0" style="border-radius:12px;overflow:hidden;" title="Soroban Guard Security Status"></iframe>`
+  }
+
+  function handleCopyEmbed() {
+    navigator.clipboard.writeText(getEmbedSnippet())
+    setEmbedCopied(true)
+    setTimeout(() => setEmbedCopied(false), 2000)
   }
 
   async function handleRescan() {
@@ -177,6 +196,17 @@ export default function ResultsPage() {
                   <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
                 </svg>
                 Create GitHub Issues
+              </button>
+            )}
+            {getEmbedToken() && (
+              <button
+                onClick={() => setShowEmbedModal(true)}
+                className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                </svg>
+                Get embed code
               </button>
             )}
             <button
@@ -351,6 +381,38 @@ export default function ResultsPage() {
 
       {showGithubModal && (
         <GithubExportModal findings={findings} onClose={() => setShowGithubModal(false)} />
+      )}
+
+      {showEmbedModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          onClick={() => setShowEmbedModal(false)}
+        >
+          <div
+            className="w-full max-w-lg rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] p-6 shadow-2xl"
+            onClick={e => e.stopPropagation()}
+          >
+            <h2 className="mb-1 text-base font-semibold text-white">Embed security status</h2>
+            <p className="mb-4 text-sm text-slate-400">Copy the snippet below and paste it into your README or website.</p>
+            <pre className="mb-4 overflow-x-auto rounded-lg bg-[#12151f] p-3 text-xs text-slate-300 whitespace-pre-wrap break-all">
+              {getEmbedSnippet()}
+            </pre>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowEmbedModal(false)}
+                className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm text-slate-400 transition hover:text-white"
+              >
+                Close
+              </button>
+              <button
+                onClick={handleCopyEmbed}
+                className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500"
+              >
+                {embedCopied ? 'Copied!' : 'Copy snippet'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
- app/embed/[token]/page.tsx: minimal 300x150 embed page showing score, High/Medium/Low counts, scan date, and 'Powered by Soroban Guard' link
- app/results/ResultsClient.tsx: 'Get embed code' button in header that opens a modal with a copyable iframe snippet pointing to /embed/{token}
- Token is derived from the shareable results URL 'r' param (issue #18)

Closes #136

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
