### PR TITLE
feat: add Markdown export for scan findings (#134)

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import type { Finding, Severity } from '@/types/findings'
 import { decodeFindings } from '@/lib/share'
-import { exportEmail } from '@/lib/export'
+import { exportEmail, downloadMarkdown } from '@/lib/export'
 import { getAllScanHistory } from '@/lib/history'
 import { diffFindings } from '@/lib/diffFindings'
 import FindingsTable from '@/components/FindingsTable'
@@ -168,6 +168,18 @@ export default function ResultsPage() {
             >
               Email summary
             </a>
+            <button
+              onClick={() => downloadMarkdown(findings, {
+                source: sessionStorage.getItem('sg_last_scan_source') ?? 'unknown',
+                scannedAt: new Date().toISOString(),
+              })}
+              className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Download Markdown
+            </button>
             {findings.length > 0 && (
               <button
                 onClick={() => setShowGithubModal(true)}

--- a/lib/export.ts
+++ b/lib/export.ts
@@ -1,5 +1,60 @@
 import type { Finding } from '@/types/findings'
 
+export function exportMarkdown(
+  findings: Finding[],
+  metadata: { source: string; scannedAt: string },
+): string {
+  const counts: Record<string, number> = { Critical: 0, High: 0, Medium: 0, Low: 0 }
+  for (const f of findings) counts[f.severity] = (counts[f.severity] ?? 0) + 1
+
+  const lines: string[] = [
+    '# Soroban Guard Security Report',
+    '',
+    `**Source:** ${metadata.source}`,
+    `**Scanned at:** ${metadata.scannedAt}`,
+    '',
+    '## Summary',
+    '',
+    '| Severity | Count |',
+    '|----------|-------|',
+    `| Critical | ${counts.Critical ?? 0} |`,
+    `| High     | ${counts.High ?? 0} |`,
+    `| Medium   | ${counts.Medium ?? 0} |`,
+    `| Low      | ${counts.Low ?? 0} |`,
+    `| **Total**| **${findings.length}** |`,
+    '',
+  ]
+
+  if (findings.length === 0) {
+    lines.push('No vulnerabilities found.')
+  } else {
+    lines.push('## Findings', '')
+    for (const f of findings) {
+      lines.push(
+        `### [${f.severity}] ${f.check_name}`,
+        '',
+        `- **Function:** \`${f.function_name}\``,
+        `- **File:** \`${f.file_path}\` (line ${f.line})`,
+        `- **Description:** ${f.description}`,
+      )
+      if (f.remediation) lines.push(`- **Remediation:** ${f.remediation}`)
+      lines.push('')
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function downloadMarkdown(findings: Finding[], metadata: { source: string; scannedAt: string }) {
+  try {
+    const content = exportMarkdown(findings, metadata)
+    const blob = new Blob([content], { type: 'text/markdown' })
+    download('soroban-guard-report.md', blob)
+  } catch (err) {
+    console.error('downloadMarkdown failed', err)
+  }
+}
+
 function download(filename: string, data: Blob) {
   const url = URL.createObjectURL(data)
   const a = document.createElement('a')


### PR DESCRIPTION
- lib/export.ts: exportMarkdown() generates a Markdown report with a summary table (severity counts) and per-finding sections with all fields
- lib/export.ts: downloadMarkdown() triggers browser download as soroban-guard-report.md
- app/results/ResultsClient.tsx: 'Download Markdown' button added alongside existing Email summary export in the results header

Closes #134

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
