### PR TITLE
feat: Telegram bot notifications for scan results (#139)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,6 +23,7 @@ import { saveSourceCode } from '@/lib/codeStore'
 import { notify } from '@/lib/notifications'
 import { FEATURED_CONTRACTS } from '@/lib/featuredContracts'
 import ScanQuotaIndicator from '@/components/ScanQuota'
+import { postToTelegram } from '@/lib/telegram'
 
 export default function Page() {
   return (
@@ -45,7 +46,7 @@ function HomePage() {
 
   const activeNetwork = walletKey ? walletNetwork : manualNetwork
 
-  async function handleScan(source: string, mode: 'code' | 'github' | 'contractId' | 'ipfs' = 'code') {
+  async function handleScan(source: string, mode: 'code' | 'github' | 'contractId' | 'ipfs' = 'code', telegramConfig?: { botToken: string; chatId: string }) {
     setLoading(true)
     setError(null)
     setRateLimitCountdown(null)
@@ -65,6 +66,11 @@ function HomePage() {
       sessionStorage.setItem('sg_findings', JSON.stringify(data.findings))
       sessionStorage.setItem('sg_duration', duration)
       notify('Scan complete', `${data.findings.length} finding${data.findings.length !== 1 ? 's' : ''} detected`)
+      if (telegramConfig?.botToken && telegramConfig?.chatId) {
+        postToTelegram(telegramConfig.botToken, telegramConfig.chatId, data.findings, source).catch(err => {
+          console.warn('Telegram notification failed:', err)
+        })
+      }
       router.push(`/results?r=${encoded}`)
     } catch (err) {
       if (err instanceof ApiError && err.status === 429 && err.retryAfter) {

--- a/components/ScanInput.tsx
+++ b/components/ScanInput.tsx
@@ -7,11 +7,13 @@ import { requestPermission } from '@/lib/notifications'
 import { extractContractIdFromUrl } from '@/lib/stellar'
 
 const NOTIF_PREF_KEY = 'sg_notifications_enabled'
+const TG_BOT_TOKEN_KEY = 'sg_tg_bot_token'
+const TG_CHAT_ID_KEY = 'sg_tg_chat_id'
 
 type InputMode = 'code' | 'github' | 'contractId' | 'ipfs'
 
 interface Props {
-  onScan: (source: string, mode: InputMode) => void
+  onScan: (source: string, mode: InputMode, telegramConfig?: { botToken: string; chatId: string }) => void
   loading: boolean
   countdown?: number
   initialValue?: string
@@ -46,6 +48,13 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
     if (typeof window === 'undefined') return false
     return localStorage.getItem(NOTIF_PREF_KEY) === 'true'
   })
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [tgBotToken, setTgBotToken] = useState(() =>
+    typeof window !== 'undefined' ? (localStorage.getItem(TG_BOT_TOKEN_KEY) ?? '') : ''
+  )
+  const [tgChatId, setTgChatId] = useState(() =>
+    typeof window !== 'undefined' ? (localStorage.getItem(TG_CHAT_ID_KEY) ?? '') : ''
+  )
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const normalizedTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -109,7 +118,7 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (mode === 'ipfs') {
-      if (ipfsPreview) onScan(ipfsPreview, mode)
+      if (ipfsPreview) onScan(ipfsPreview, mode, tgBotToken && tgChatId ? { botToken: tgBotToken, chatId: tgChatId } : undefined)
       return
     }
     const source =
@@ -119,7 +128,7 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
           ? repoUrl.trim()
           : contractId.trim()
     if (!source) return
-    onScan(source, mode)
+    onScan(source, mode, tgBotToken && tgChatId ? { botToken: tgBotToken, chatId: tgChatId } : undefined)
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -338,6 +347,55 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
           </button>
         </div>
       )}
+
+      {/* Advanced options */}
+      <div>
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(v => !v)}
+          className="flex items-center gap-1.5 text-xs text-slate-500 transition hover:text-slate-300"
+        >
+          <svg
+            className={`h-3.5 w-3.5 transition-transform ${showAdvanced ? 'rotate-90' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+          Advanced options
+        </button>
+        {showAdvanced && (
+          <div className="mt-3 space-y-3 rounded-xl border border-[#2a2d3a] bg-[#12151f] p-4">
+            <p className="text-xs font-medium text-slate-400">Telegram notifications</p>
+            <div className="space-y-2">
+              <input
+                type="text"
+                value={tgBotToken}
+                onChange={e => {
+                  setTgBotToken(e.target.value)
+                  localStorage.setItem(TG_BOT_TOKEN_KEY, e.target.value)
+                }}
+                placeholder="Bot token (e.g. 123456:ABC-DEF…)"
+                className="w-full rounded-lg border border-[#2a2d3a] bg-[#0d0f17] px-3 py-2 text-xs text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60"
+                disabled={loading}
+              />
+              <input
+                type="text"
+                value={tgChatId}
+                onChange={e => {
+                  setTgChatId(e.target.value)
+                  localStorage.setItem(TG_CHAT_ID_KEY, e.target.value)
+                }}
+                placeholder="Chat ID (e.g. -1001234567890)"
+                className="w-full rounded-lg border border-[#2a2d3a] bg-[#0d0f17] px-3 py-2 text-xs text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60"
+                disabled={loading}
+              />
+              <p className="text-xs text-slate-600">
+                Results will be sent to your Telegram chat after a successful scan.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
 
       {/* Submit */}
       <div className="space-y-2">

--- a/lib/telegram.ts
+++ b/lib/telegram.ts
@@ -1,0 +1,48 @@
+import type { Finding } from '@/types/findings'
+
+const TELEGRAM_API = 'https://api.telegram.org'
+
+export async function postToTelegram(
+  botToken: string,
+  chatId: string,
+  findings: Finding[],
+  source: string,
+): Promise<void> {
+  const counts: Record<string, number> = { Critical: 0, High: 0, Medium: 0, Low: 0 }
+  for (const f of findings) counts[f.severity] = (counts[f.severity] ?? 0) + 1
+
+  const top3 = findings
+    .sort((a, b) => {
+      const order: Record<string, number> = { Critical: 0, High: 1, Medium: 2, Low: 3 }
+      return (order[a.severity] ?? 4) - (order[b.severity] ?? 4)
+    })
+    .slice(0, 3)
+
+  const lines = [
+    `🛡 *Soroban Guard Scan Results*`,
+    `Source: \`${source}\``,
+    '',
+    `*Critical:* ${counts.Critical}  *High:* ${counts.High}  *Medium:* ${counts.Medium}  *Low:* ${counts.Low}`,
+    `*Total findings:* ${findings.length}`,
+  ]
+
+  if (top3.length > 0) {
+    lines.push('', '*Top findings:*')
+    for (const f of top3) {
+      lines.push(`• *[${f.severity}]* ${f.check_name} — \`${f.function_name}\``)
+    }
+  }
+
+  const text = lines.join('\n')
+
+  const res = await fetch(`${TELEGRAM_API}/bot${botToken}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: 'Markdown' }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Telegram API error ${res.status}: ${body}`)
+  }
+}


### PR DESCRIPTION
- lib/telegram.ts: postToTelegram() sends scan results to a Telegram chat using the Bot API sendMessage endpoint with Markdown formatting; includes severity counts and top 3 findings
- components/ScanInput.tsx: 'Advanced options' collapsible section with Telegram bot token and chat ID fields; values persist in localStorage
- app/page.tsx: calls postToTelegram after a successful scan if configured; failure does not block scan result navigation

Closes #139

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
