### PR TITLE
Add XML export functionality for enterprise tooling

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import type { Finding, Severity } from '@/types/findings'
 import { decodeFindings } from '@/lib/share'
-import { exportEmail } from '@/lib/export'
+import { exportEmail, exportXml } from '@/lib/export'
 import { getAllScanHistory } from '@/lib/history'
 import { diffFindings } from '@/lib/diffFindings'
 import FindingsTable from '@/components/FindingsTable'
@@ -168,6 +168,12 @@ export default function ResultsPage() {
             >
               Email summary
             </a>
+            <button
+              onClick={() => exportXml(findings)}
+              className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+            >
+              Export XML
+            </button>
             {findings.length > 0 && (
               <button
                 onClick={() => setShowGithubModal(true)}

--- a/lib/export.ts
+++ b/lib/export.ts
@@ -63,3 +63,68 @@ export function exportCsv(findings: Finding[]) {
     console.error('exportCsv failed', err)
   }
 }
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export function exportXml(findings: Finding[]) {
+  try {
+    const timestamp = new Date().toISOString()
+    const totalFindings = findings.length
+    const severityCounts = findings.reduce((acc, finding) => {
+      acc[finding.severity] = (acc[finding.severity] || 0) + 1
+      return acc
+    }, {} as Record<string, number>)
+
+    let xml = `<?xml version="1.0" encoding="UTF-8"?>
+<scanReport>
+  <metadata>
+    <tool>Soroban Guard</tool>
+    <version>1.0.0</version>
+    <timestamp>${timestamp}</timestamp>
+    <totalFindings>${totalFindings}</totalFindings>
+    <severityCounts>
+      <critical count="${severityCounts.Critical || 0}" />
+      <high count="${severityCounts.High || 0}" />
+      <medium count="${severityCounts.Medium || 0}" />
+      <low count="${severityCounts.Low || 0}" />
+    </severityCounts>
+  </metadata>
+  <findings>`
+
+    if (findings.length === 0) {
+      xml += `
+    <finding>
+      <message>No vulnerabilities detected</message>
+    </finding>`
+    } else {
+      findings.forEach((finding, index) => {
+        xml += `
+    <finding id="${index + 1}">
+      <severity>${escapeXml(finding.severity)}</severity>
+      <checkName>${escapeXml(finding.check_name)}</checkName>
+      <functionName>${escapeXml(finding.function_name)}</functionName>
+      <filePath>${escapeXml(finding.file_path)}</filePath>
+      <line>${finding.line}</line>
+      <description>${escapeXml(finding.description)}</description>
+      ${finding.remediation ? `<remediation>${escapeXml(finding.remediation)}</remediation>` : ''}
+    </finding>`
+      })
+    }
+
+    xml += `
+  </findings>
+</scanReport>`
+
+    const blob = new Blob([xml], { type: 'application/xml' })
+    download('soroban-guard-scan-results.xml', blob)
+  } catch (err) {
+    console.error('exportXml failed', err)
+  }
+}


### PR DESCRIPTION
- Add exportXml() function to generate structured XML reports
- Include metadata with severity counts and timestamps
- Add Export XML button to results page UI
- Support proper XML escaping for special characters
- Enable enterprise tooling integration with standardized format

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->
Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated..closed #135 
