### PR TITLE
Add a 'Scan from npm package' input mode for JS/TS Soroban SDKs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,7 +45,7 @@ function HomePage() {
 
   const activeNetwork = walletKey ? walletNetwork : manualNetwork
 
-  async function handleScan(source: string, mode: 'code' | 'github' | 'contractId' | 'ipfs' = 'code') {
+  async function handleScan(source: string, mode: 'code' | 'github' | 'contractId' | 'ipfs' | 'npm' = 'code') {
     setLoading(true)
     setError(null)
     setRateLimitCountdown(null)

--- a/components/ScanInput.tsx
+++ b/components/ScanInput.tsx
@@ -3,12 +3,14 @@
 import { useState, useRef } from 'react'
 import { SAMPLE_CONTRACT } from '@/lib/sampleContract'
 import { isValidCid, fetchFromIpfs } from '@/lib/ipfs'
+import { isValidNpmPackage, fetchNpmSource } from '@/lib/npm'
 import { requestPermission } from '@/lib/notifications'
 import { extractContractIdFromUrl } from '@/lib/stellar'
 
 const NOTIF_PREF_KEY = 'sg_notifications_enabled'
+const NPM_PREVIEW_LIMIT = 5_000
 
-type InputMode = 'code' | 'github' | 'contractId' | 'ipfs'
+type InputMode = 'code' | 'github' | 'contractId' | 'ipfs' | 'npm'
 
 interface Props {
   onScan: (source: string, mode: InputMode) => void
@@ -40,6 +42,12 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
   const [ipfsPreview, setIpfsPreview] = useState<string | null>(null)
   const [ipfsFetching, setIpfsFetching] = useState(false)
   const [ipfsError, setIpfsError] = useState<string | null>(null)
+  const [packageName, setPackageName] = useState('')
+  const [npmVersion, setNpmVersion] = useState('')
+  const [npmPreview, setNpmPreview] = useState<string | null>(null)
+  const [npmFetching, setNpmFetching] = useState(false)
+  const [npmError, setNpmError] = useState<string | null>(null)
+  const [npmPackageValid, setNpmPackageValid] = useState(false)
   const [normalized, setNormalized] = useState(false)
   const [extractedFromUrl, setExtractedFromUrl] = useState(false)
   const [notificationsEnabled, setNotificationsEnabled] = useState(() => {
@@ -94,6 +102,32 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
     }
   }
 
+  function handleNpmPackageChange(value: string) {
+    setPackageName(value)
+    setNpmPreview(null)
+    const valid = isValidNpmPackage(value)
+    setNpmPackageValid(valid)
+    setNpmError(value.trim() && !valid ? 'Invalid package name - use lowercase npm package format (e.g., @scope/package-name)' : null)
+  }
+
+  async function handleFetchNpm() {
+    if (!isValidNpmPackage(packageName)) {
+      setNpmError('Invalid package name - use lowercase npm package format (e.g., @scope/package-name)')
+      return
+    }
+    setNpmFetching(true)
+    setNpmError(null)
+    setNpmPreview(null)
+    try {
+      const content = await fetchNpmSource(packageName, npmVersion || undefined)
+      setNpmPreview(content)
+    } catch (err) {
+      setNpmError(err instanceof Error ? err.message : 'Failed to fetch npm package')
+    } finally {
+      setNpmFetching(false)
+    }
+  }
+
   async function toggleNotifications() {
     if (!notificationsEnabled) {
       const granted = await requestPermission()
@@ -110,6 +144,10 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
     e.preventDefault()
     if (mode === 'ipfs') {
       if (ipfsPreview) onScan(ipfsPreview, mode)
+      return
+    }
+    if (mode === 'npm') {
+      if (npmPreview) onScan(npmPreview, mode)
       return
     }
     const source =
@@ -140,7 +178,12 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
         ? repoUrl.trim().length > 0 && repoValidation.valid
         : mode === 'contractId'
           ? contractId.trim().length > 0 && contractValid
-          : ipfsPreview !== null)
+          : mode === 'ipfs'
+            ? ipfsPreview !== null
+            : npmPreview !== null)
+
+  const npmPreviewText = npmPreview ? npmPreview.slice(0, NPM_PREVIEW_LIMIT) : ''
+  const npmPreviewTruncated = !!npmPreview && npmPreview.length > NPM_PREVIEW_LIMIT
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -189,6 +232,17 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
           }
         >
           IPFS CID
+        </TabButton>
+        <TabButton
+          active={mode === 'npm'}
+          onClick={() => setMode('npm')}
+          icon={
+            <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M1 8h22v8H1zM7 12h3v4H7zm5 0h3v4h-3zm5 0h3v4h-3z" />
+            </svg>
+          }
+        >
+          npm Package
         </TabButton>
       </div>
 
@@ -267,7 +321,7 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
             will fetch the WASM bytecode via Soroban RPC and analyze it.
           </p>
         </div>
-      ) : (
+      ) : mode === 'ipfs' ? (
         <div className="space-y-2">
           <div className="flex gap-2">
             <input
@@ -313,6 +367,83 @@ export default function ScanInput({ onScan, loading, countdown = 0, initialValue
               <textarea
                 readOnly
                 value={ipfsPreview}
+                rows={10}
+                className="code-textarea w-full resize-y rounded-xl border border-emerald-500/30 bg-[#12151f] px-4 py-3 text-sm text-slate-400 outline-none"
+                spellCheck={false}
+              />
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={packageName}
+              onChange={e => handleNpmPackageChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="@scope/package or package-name"
+              className={`flex-1 rounded-xl border bg-[#12151f] px-4 py-3 font-mono text-sm text-slate-300 placeholder-slate-600 outline-none transition focus:ring-1 ${
+                npmError
+                  ? 'border-rose-500/50 focus:border-rose-500 focus:ring-rose-500/30'
+                  : 'border-[#2a2d3a] focus:border-indigo-500/60 focus:ring-indigo-500/30'
+              }`}
+              disabled={loading || npmFetching}
+              spellCheck={false}
+            />
+            <input
+              type="text"
+              value={npmVersion}
+              onChange={e => setNpmVersion(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="version (optional)"
+              className="w-24 rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 font-mono text-sm text-slate-300 placeholder-slate-600 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
+              disabled={loading || npmFetching}
+              spellCheck={false}
+            />
+            <button
+              type="button"
+              onClick={handleFetchNpm}
+              disabled={!npmPackageValid || npmFetching || loading}
+              className="flex items-center gap-1.5 rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 text-sm text-slate-300 transition hover:border-indigo-500/50 hover:text-indigo-300 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {npmFetching ? (
+                <svg className="spinner h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                  <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
+                </svg>
+              ) : (
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+                </svg>
+              )}
+              Fetch
+            </button>
+          </div>
+          {npmError && <p className="text-xs text-rose-400">{npmError}</p>}
+          {!npmError && !npmPreview && packageName.length > 0 && (
+            <p className="text-xs text-slate-500">
+              Enter an npm package name to fetch the main entry file from unpkg.com.
+            </p>
+          )}
+          {!npmError && !npmPreview && packageName.length === 0 && (
+            <p className="text-xs text-slate-500">
+              Enter a package name (e.g., <code className="rounded bg-[#1a1d27] px-1 text-slate-400">soroban-rs</code> or{' '}
+              <code className="rounded bg-[#1a1d27] px-1 text-slate-400">@scope/package</code>) and click Fetch.
+            </p>
+          )}
+          {npmPreview !== null && (
+            <div className="space-y-1">
+              <p className="text-xs text-emerald-400">
+                ✓ Fetched {npmPreview.length.toLocaleString()} chars — preview below
+              </p>
+              {npmPreviewTruncated && (
+                <p className="text-xs text-slate-500">
+                  Showing the first {NPM_PREVIEW_LIMIT.toLocaleString()} chars. The full fetched file will be scanned.
+                </p>
+              )}
+              <textarea
+                readOnly
+                value={npmPreviewText}
                 rows={10}
                 className="code-textarea w-full resize-y rounded-xl border border-emerald-500/30 bg-[#12151f] px-4 py-3 text-sm text-slate-400 outline-none"
                 spellCheck={false}

--- a/lib/npm.ts
+++ b/lib/npm.ts
@@ -1,0 +1,69 @@
+const NPM_PACKAGE_SEGMENT_RE = /^[a-z0-9][a-z0-9._-]*$/
+const NPM_PACKAGE_NAME_RE = /^(?:@([a-z0-9][a-z0-9._-]*)\/)?([a-z0-9][a-z0-9._-]*)$/
+const MAX_NPM_SOURCE_CHARS = 100_000
+
+export function isValidNpmPackage(packageName: string): boolean {
+  const trimmed = packageName.trim()
+  if (trimmed.length === 0 || trimmed.length > 214) return false
+  return NPM_PACKAGE_NAME_RE.test(trimmed)
+}
+
+function buildUnpkgPackagePath(packageName: string): string {
+  const trimmed = packageName.trim()
+  const scopedMatch = trimmed.match(/^@([^/]+)\/(.+)$/)
+
+  if (scopedMatch) {
+    const [, scope, name] = scopedMatch
+    return `@${encodeURIComponent(scope)}/${encodeURIComponent(name)}`
+  }
+
+  if (!NPM_PACKAGE_SEGMENT_RE.test(trimmed)) {
+    throw new Error('Invalid package name')
+  }
+
+  return encodeURIComponent(trimmed)
+}
+
+export async function fetchNpmSource(packageName: string, version?: string): Promise<string> {
+  const trimmed = packageName.trim()
+  if (!isValidNpmPackage(trimmed)) {
+    throw new Error('Invalid package name - use lowercase npm package format (e.g., @scope/package-name)')
+  }
+
+  const versionStr = version?.trim() ? `@${encodeURIComponent(version.trim())}` : ''
+  const url = `https://unpkg.com/${buildUnpkgPackagePath(trimmed)}${versionStr}`
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 15_000)
+
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+    })
+
+    if (!res.ok) {
+      if (res.status === 404) {
+        throw new Error('Package not found on npm')
+      }
+      throw new Error(`unpkg returned ${res.status}`)
+    }
+
+    const content = await res.text()
+
+    if (content.length > MAX_NPM_SOURCE_CHARS) {
+      throw new Error(`File too large (${content.length.toLocaleString()} chars) - maximum 100,000 characters`)
+    }
+
+    return content
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('npm package fetch timed out after 15 s')
+    }
+    if (err instanceof Error && err.message.includes('too large')) {
+      throw err
+    }
+    throw err instanceof Error ? err : new Error('Failed to fetch npm package')
+  } finally {
+    clearTimeout(timeout)
+  }
+}


### PR DESCRIPTION
Closes #125

---

This PR:

Adds an npm Package tab to ScanInput
Adds fetchNpmSource(packageName, version?) in lib/npm.ts
Validates npm package names before fetching
Supports optional package versions, defaulting to latest when omitted
Fetches the main unpkg entry file for valid packages
Shows fetched file size before scanning
Shows a truncated preview while keeping the full fetched source for scanning
Rejects fetched files over 100,000 characters with an inline error
Shows inline validation errors for invalid npm package names
Updates scan mode typing to include npm
Closes #

Checklist
- [x] TypeScript compiles with no errors (`npm run build`)
- [x] ESLint passes (`npm run lint`)
- [x] Tested in browser (Chrome + Firefox)
- [x] Mobile layout checked
- [x] No `console.log` left in code
- [] Relevant docs updated
