### PR TITLE
feat: add real-time findings search filter

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -167,6 +167,17 @@ export default function ResultsClient() {
   const counts: Record<Severity, number> = { Critical: 0, High: 0, Medium: 0, Low: 0 }
   for (const f of findings) counts[f.severity]++
 
+  const q = searchQuery.toLowerCase()
+  const filteredFindings = q
+    ? findings.filter(
+        f =>
+          f.check_name.toLowerCase().includes(q) ||
+          f.function_name.toLowerCase().includes(q) ||
+          f.file_path.toLowerCase().includes(q) ||
+          f.description.toLowerCase().includes(q),
+      )
+    : findings
+
   const canCopy = typeof navigator !== 'undefined' && navigator.clipboard
 
   return (


### PR DESCRIPTION
Closes #170

---

## Summary

Fixes the missing `filteredFindings` derived variable in `ResultsClient.tsx` that was referenced but never defined, completing the real-time search feature.

## Changes

- **`app/results/ResultsClient.tsx`** — added `filteredFindings` computed from `searchQuery` state, filtering on `check_name`, `function_name`, `file_path`, and `description` (case-insensitive)

## Acceptance criteria met

- ✅ Case-insensitive partial string matching
- ✅ Updates on every keystroke (no debounce)
- ✅ Clear (×) button resets the filter
- ✅ "No findings match your search" empty state when zero results
- ✅ Ready for AND logic with severity filter chips (Issue #4)