### PR TITLE
feat: add Content Security Policy headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,31 @@
 /** @type {import('next').NextConfig} */
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https:",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+    ].join('; '),
+  },
+]
+
 const nextConfig = {
   reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- add a Content-Security-Policy header through Next.js headers config
- apply the policy across all app routes with self defaults and restricted framing/form targets

Closes #306

## Verification
- npm run lint
- npm run build