### PR TITLE
feat: add retry with exponential backoff to scanContract

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -33,42 +33,67 @@ export async function scanContract(source: string, network?: StellarNetwork): Pr
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (network) headers['X-Network'] = network.name
 
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), 30000)
+  const MAX_ATTEMPTS = 3
+  let attempt = 1
 
-  const res = await fetch(`${API_BASE}/scan`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
-    signal: controller.signal,
-  })
+  while (true) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 30000)
 
-  clearTimeout(timeoutId)
-
-  if (!res.ok) {
-    if (res.status === 429) {
-      const retryAfterHeader = res.headers.get('Retry-After')
-      const retryAfter = retryAfterHeader ? Math.ceil(parseFloat(retryAfterHeader)) : 60
-      throw new ApiError(429, 'Rate limited', retryAfter)
+    let res: Response
+    try {
+      res = await fetch(`${API_BASE}/scan`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+    } catch (fetchErr) {
+      clearTimeout(timeoutId)
+      if (attempt < MAX_ATTEMPTS) {
+        const delay = Math.pow(2, attempt - 1) * 1000
+        attempt++
+        await new Promise((resolve) => setTimeout(resolve, delay))
+        continue
+      }
+      throw fetchErr
     }
-    const text = await res.text().catch(() => 'Unknown error')
-    throw new ApiError(res.status, text || `HTTP ${res.status}`)
+
+    clearTimeout(timeoutId)
+
+    if (!res.ok) {
+      if (res.status === 429) {
+        const retryAfterHeader = res.headers.get('Retry-After')
+        const retryAfter = retryAfterHeader ? Math.ceil(parseFloat(retryAfterHeader)) : 60
+        throw new ApiError(429, 'Rate limited', retryAfter)
+      }
+
+      if (res.status >= 500 && res.status < 600 && attempt < MAX_ATTEMPTS) {
+        const delay = Math.pow(2, attempt - 1) * 1000
+        attempt++
+        await new Promise((resolve) => setTimeout(resolve, delay))
+        continue
+      }
+
+      const text = await res.text().catch(() => 'Unknown error')
+      throw new ApiError(res.status, text || `HTTP ${res.status}`)
+    }
+
+    const data = (await res.json()) as ScanResponse
+
+    const remaining = res.headers.get('X-RateLimit-Remaining')
+    const limit = res.headers.get('X-RateLimit-Limit')
+    const reset = res.headers.get('X-RateLimit-Reset')
+
+    const quota: ScanQuota | undefined =
+      remaining !== null && limit !== null && reset !== null
+        ? {
+            remaining: parseInt(remaining, 10),
+            limit: parseInt(limit, 10),
+            resetAt: parseInt(reset, 10) * 1000, // convert epoch seconds → ms
+          }
+        : undefined
+
+    return { ...data, quota }
   }
-
-  const data = (await res.json()) as ScanResponse
-
-  const remaining = res.headers.get('X-RateLimit-Remaining')
-  const limit = res.headers.get('X-RateLimit-Limit')
-  const reset = res.headers.get('X-RateLimit-Reset')
-
-  const quota: ScanQuota | undefined =
-    remaining !== null && limit !== null && reset !== null
-      ? {
-          remaining: parseInt(remaining, 10),
-          limit: parseInt(limit, 10),
-          resetAt: parseInt(reset, 10) * 1000, // convert epoch seconds → ms
-        }
-      : undefined
-
-  return { ...data, quota }
 }


### PR DESCRIPTION
feat: Add Automatic Retry with Exponential Backoff to scanContract
Description
This Pull Request introduces automatic retry capabilities with exponential backoff to the scanContract function in lib/api.ts. It provides resilience against transient server errors (HTTP 5xx) and low-level network failures (e.g. timeout, DNS resolution, connection drops), ensuring a seamless user experience during transient API downtime.

Rate limit errors (HTTP 429) are intentionally excluded from the internal retry logic to allow the custom rate limit banner and countdown timers in the React components to operate correctly.

Key Changes
Loop-based Retry Mechanism: Replaced the single-attempt request in scanContract with an attempt loop capped at a maximum of 3 total attempts (MAX_ATTEMPTS = 3).
Isolated Network Exception Handling: Wrapped the fetch call inside a dedicated try/catch block. This guarantees that low-level network issues and 30-second client-side timeouts (AbortError) trigger a retry, while code-level exceptions (such as JSON parsing bugs) fail immediately.
Transient 5xx Classification: Added verification for response status codes; any HTTP response code in the range $500\text{--}599$ triggers an automatic retry.
Exponential Backoff: Implemented standard exponential backoff spacing:
Failure 1: Wait $1000\text{ ms}$ ($1\text{ second}$) before Attempt 2.
Failure 2: Wait $2000\text{ ms}$ ($2\text{ seconds}$) before Attempt 3.
Failure 3: Propagates the final error to the caller.
Preservation of 429 Logic: Rate limiting responses bypass the retry loop and throw immediately to preserve existing React-level countdown timers.
Technical Details
Exponential Backoff Computation
The sleep delay between retries is calculated using: $$\text{delay} = 2^{(\text{attempt} - 1)} \times 1000\text{ ms}$$

Code snippet of the retry flow:
typescript
const MAX_ATTEMPTS = 3
let attempt = 1
while (true) {
  const controller = new AbortController()
  const timeoutId = setTimeout(() => controller.abort(), 30000)
  let res: Response
  try {
    res = await fetch(`${API_BASE}/scan`, {
      method: 'POST',
      headers,
      body: JSON.stringify(body),
      signal: controller.signal,
    })
  } catch (fetchErr) {
    clearTimeout(timeoutId)
    if (attempt < MAX_ATTEMPTS) {
      const delay = Math.pow(2, attempt - 1) * 1000
      attempt++
      await new Promise((resolve) => setTimeout(resolve, delay))
      continue
    }
    throw fetchErr
  }
  clearTimeout(timeoutId)
  // ... check status & retry 5xx, or return payload ...
}
closes #204 