### PR TITLE
feat: Info severity, PDF export, theme persistence, keyboard shortcut modal

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -18,6 +18,8 @@ import SeverityBadge from '@/components/SeverityBadge'
 import SeverityDonut from '@/components/SeverityDonut'
 import FindingsSkeleton from '@/components/FindingsSkeleton'
 import ThemeToggle from '@/components/ThemeToggle'
+import { generatePdfReport } from '@/lib/pdfReport'
+import { calculateScore } from '@/lib/score'
 import { useToast } from '@/lib/toast'
 import { useWallet } from '@/lib/WalletContext'
 import GithubExportModal from '@/components/GithubExportModal'
@@ -45,6 +47,7 @@ export default function ResultsClient() {
   const [showDiff, setShowDiff] = useState(false)
   const [groupView, setGroupView] = useState<'flat' | 'function'>('flat')
   const [navIndex, setNavIndex] = useState<number | null>(null)
+  const [showShortcutsModal, setShowShortcutsModal] = useState(false)
   const hasSource = Boolean(scanSource)
 
   useEffect(() => {
@@ -71,6 +74,11 @@ export default function ResultsClient() {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if (e.key === '?') {
+        e.preventDefault()
+        setShowShortcutsModal(v => !v)
+        return
+      }
       if (findings && (e.key === 'j' || e.key === 'k')) {
         e.preventDefault()
         const current = navIndex ?? -1
@@ -176,8 +184,15 @@ export default function ResultsClient() {
     show('Attest feature is not enabled in this build.', 'info')
   }
 
-  function handleDownloadSarif() {
-    const content = exportSarif(findings ?? [])
+  function handleDownloadPdf() {
+    generatePdfReport(findings ?? [], {
+      source: scanSource ?? 'Unknown',
+      scannedAt: new Date().toISOString(),
+      score: calculateScore(findings ?? []),
+    })
+  }
+
+  function handleDownloadSarif() {    const content = exportSarif(findings ?? [])
     const blob = new Blob([content], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -267,6 +282,12 @@ export default function ResultsClient() {
               className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
             >
               Download SARIF
+            </button>
+            <button
+              onClick={handleDownloadPdf}
+              className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+            >
+              Download PDF
             </button>
             {findings.length > 0 && (
               <button
@@ -414,6 +435,13 @@ export default function ResultsClient() {
                   bg="bg-sky-500/5"
                   border="border-sky-500/20"
                 />
+                <SummaryCard
+                  label="Info"
+                  value={counts.Info}
+                  color="text-slate-400"
+                  bg="bg-slate-500/5"
+                  border="border-slate-500/20"
+                />
                 {duration && (
                   <SummaryCard
                     label="Scan Time"
@@ -500,7 +528,7 @@ export default function ResultsClient() {
                     </button>
                   </div>
                 )}
-                {(['High', 'Medium', 'Low'] as Severity[]).map(s =>
+                {(['Critical', 'High', 'Medium', 'Low', 'Info'] as Severity[]).map(s =>
                   counts[s] > 0 ? (
                     <SeverityBadge key={s} severity={s} size="sm" />
                   ) : null,
@@ -583,6 +611,51 @@ export default function ResultsClient() {
       )}
       {showNotionModal && (
         <NotionExportModal findings={findings} onClose={() => setShowNotionModal(false)} />
+      )}
+      {showShortcutsModal && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Keyboard shortcuts"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          onClick={() => setShowShortcutsModal(false)}
+        >
+          <div
+            className="w-full max-w-sm rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] p-6 shadow-2xl"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-base font-semibold text-white">Keyboard Shortcuts</h2>
+              <button
+                onClick={() => setShowShortcutsModal(false)}
+                aria-label="Close"
+                className="text-slate-400 hover:text-white"
+              >
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <table className="w-full text-sm">
+              <tbody className="divide-y divide-[var(--border)]">
+                {[
+                  ['j', 'Next finding'],
+                  ['k', 'Previous finding'],
+                  ['?', 'Toggle this help'],
+                ].map(([key, desc]) => (
+                  <tr key={key}>
+                    <td className="py-2 pr-4">
+                      <kbd className="rounded border border-[var(--border)] bg-[var(--bg)] px-2 py-0.5 font-mono text-xs text-slate-300">
+                        {key}
+                      </kbd>
+                    </td>
+                    <td className="py-2 text-slate-400">{desc}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

This PR resolves four issues in a single pass.

---

### #206 — Handle Info severity throughout the UI

- Added an **Info** `SummaryCard` to the summary bar so Info-level findings are counted and displayed alongside Critical / High / Medium / Low.
- Expanded the severity badge filter row (above the findings table) to include Info badges when present — it previously only showed High / Medium / Low.
- `SeverityBadge.tsx` and `lib/score.ts` already had full Info support; no changes were required there.

---

### #207 — Implement real PDF report generation

- Added a **Download PDF** button to the results page header that calls `generatePdfReport` from `lib/pdfReport.ts`.
- Imported `calculateScore` from `lib/score.ts` to compute the security score passed to the report.
- `lib/pdfReport.ts` opens `/report` in a new tab with findings base64-encoded in query params; `app/report/page.tsx` decodes them and triggers `window.print()` automatically — the full print-to-PDF flow was already in place but was never wired to a button.

---

### #208 — Dark/light mode persistence

- `components/ThemeToggle.tsx` already reads and writes the `sg_theme` key in `localStorage` on every toggle.
- `app/layout.tsx` already contains an inline `<script>` that reads `sg_theme` and sets `data-theme` on `<html>` before first paint, preventing any flash of unstyled content.
- No code changes were required; the feature was fully implemented.

---

### #209 — Keyboard shortcut help modal

- Added `showShortcutsModal` state to `ResultsClient.tsx`.
- Extended the existing `keydown` handler to toggle the modal on `?`.
- Rendered an accessible `role="dialog"` modal listing all shortcuts: **j** (next finding), **k** (previous finding), **?** (toggle this help).

---

## Files changed

- `app/results/ResultsClient.tsx`

Closes #206
Closes #207
Closes #208
Closes #209