### PR TITLE
feat: add unit tests for npm, wordCloud, history, and recentScans libs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,9 @@ const config = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: { module: 'commonjs' } }],
+  },
   testMatch: ['**/__tests__/**/*.test.ts'],
 }
 

--- a/lib/__tests__/history.test.ts
+++ b/lib/__tests__/history.test.ts
@@ -1,0 +1,123 @@
+import { addScanRecord, getScanHistory, getById, clearScanHistory } from '../history'
+
+const STORAGE_KEY = 'sg_scan_history'
+
+const mockLocalStorage = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: jest.fn((key: string) => store[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => { store[key] = value }),
+    removeItem: jest.fn((key: string) => { delete store[key] }),
+    clear: () => { store = {} },
+  }
+})()
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', { value: global, writable: true })
+  Object.defineProperty(global, 'localStorage', { value: mockLocalStorage, writable: true })
+})
+
+beforeEach(() => {
+  mockLocalStorage.clear()
+  jest.clearAllMocks()
+})
+
+const sampleFindings = [
+  { severity: 'High', check_name: 'reentrancy', description: 'desc', function_name: 'fn', file_path: 'src/lib.rs', line: 1 },
+  { severity: 'Medium', check_name: 'overflow', description: 'desc', function_name: 'fn', file_path: 'src/lib.rs', line: 2 },
+  { severity: 'Low', check_name: 'unused', description: 'desc', function_name: 'fn', file_path: 'src/lib.rs', line: 3 },
+]
+
+describe('addScanRecord', () => {
+  it('stores a new record in localStorage', () => {
+    addScanRecord('GPUBKEY', 'CONTRACT1', 'testnet', sampleFindings)
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, expect.any(String))
+    const stored = JSON.parse(mockLocalStorage.setItem.mock.calls[0][1])
+    expect(stored).toHaveLength(1)
+    expect(stored[0].contractId).toBe('CONTRACT1')
+    expect(stored[0].publicKey).toBe('GPUBKEY')
+    expect(stored[0].network).toBe('testnet')
+  })
+
+  it('correctly counts severity totals', () => {
+    addScanRecord('PK', 'CTR', 'mainnet', sampleFindings)
+    const stored = JSON.parse(mockLocalStorage.setItem.mock.calls[0][1])
+    expect(stored[0].highCount).toBe(1)
+    expect(stored[0].mediumCount).toBe(1)
+    expect(stored[0].lowCount).toBe(1)
+    expect(stored[0].findingCount).toBe(3)
+  })
+
+  it('stores optional score', () => {
+    addScanRecord('PK', 'CTR', 'mainnet', [], 85)
+    const stored = JSON.parse(mockLocalStorage.setItem.mock.calls[0][1])
+    expect(stored[0].score).toBe(85)
+  })
+
+  it('prepends new records (most recent first)', () => {
+    addScanRecord('PK', 'CTR1', 'mainnet', [])
+    addScanRecord('PK', 'CTR2', 'mainnet', [])
+    const stored = JSON.parse(mockLocalStorage.setItem.mock.calls[1][1])
+    expect(stored[0].contractId).toBe('CTR2')
+    expect(stored[1].contractId).toBe('CTR1')
+  })
+
+  it('caps history at 50 records', () => {
+    for (let i = 0; i < 55; i++) {
+      addScanRecord('PK', `CTR${i}`, 'testnet', [])
+    }
+    const lastCall = mockLocalStorage.setItem.mock.calls.at(-1)![1]
+    expect(JSON.parse(lastCall)).toHaveLength(50)
+  })
+})
+
+describe('getScanHistory', () => {
+  it('returns records filtered by publicKey', () => {
+    addScanRecord('ALICE', 'CTR1', 'testnet', [])
+    addScanRecord('BOB', 'CTR2', 'testnet', [])
+    const result = getScanHistory('ALICE')
+    expect(result).toHaveLength(1)
+    expect(result[0].contractId).toBe('CTR1')
+  })
+
+  it('returns empty array when no match', () => {
+    expect(getScanHistory('NOBODY')).toEqual([])
+  })
+
+  it('returns empty array when localStorage is empty', () => {
+    expect(getScanHistory('PK')).toEqual([])
+  })
+})
+
+describe('getById', () => {
+  it('returns the record with the matching id', () => {
+    addScanRecord('PK', 'CTR1', 'testnet', [])
+    const stored = JSON.parse(mockLocalStorage.setItem.mock.calls[0][1])
+    const id = stored[0].id
+    const result = getById(id)
+    expect(result).not.toBeNull()
+    expect(result!.contractId).toBe('CTR1')
+  })
+
+  it('returns null when id is not found', () => {
+    expect(getById('nonexistent-id')).toBeNull()
+  })
+
+  it('returns null when localStorage is empty', () => {
+    expect(getById('any-id')).toBeNull()
+  })
+})
+
+describe('clearScanHistory', () => {
+  it('removes the storage key', () => {
+    addScanRecord('PK', 'CTR1', 'testnet', [])
+    clearScanHistory()
+    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEY)
+  })
+
+  it('leaves history empty after clearing', () => {
+    addScanRecord('PK', 'CTR1', 'testnet', [])
+    clearScanHistory()
+    expect(getScanHistory('PK')).toEqual([])
+  })
+})

--- a/lib/__tests__/npm.test.ts
+++ b/lib/__tests__/npm.test.ts
@@ -1,0 +1,111 @@
+import { isValidNpmPackage, buildUnpkgPackagePath, fetchNpmSource } from '../npm'
+
+describe('isValidNpmPackage', () => {
+  it('accepts simple package names', () => {
+    expect(isValidNpmPackage('lodash')).toBe(true)
+    expect(isValidNpmPackage('react')).toBe(true)
+  })
+
+  it('accepts scoped packages', () => {
+    expect(isValidNpmPackage('@scope/pkg')).toBe(true)
+    expect(isValidNpmPackage('@babel/core')).toBe(true)
+  })
+
+  it('accepts names with dots, hyphens, underscores', () => {
+    expect(isValidNpmPackage('my-pkg')).toBe(true)
+    expect(isValidNpmPackage('my_pkg')).toBe(true)
+    expect(isValidNpmPackage('my.pkg')).toBe(true)
+  })
+
+  it('rejects empty or whitespace-only names', () => {
+    expect(isValidNpmPackage('')).toBe(false)
+    expect(isValidNpmPackage('   ')).toBe(false)
+  })
+
+  it('rejects names longer than 214 characters', () => {
+    expect(isValidNpmPackage('a'.repeat(215))).toBe(false)
+  })
+
+  it('rejects names with uppercase letters', () => {
+    expect(isValidNpmPackage('MyPackage')).toBe(false)
+  })
+
+  it('rejects names with invalid characters', () => {
+    expect(isValidNpmPackage('my package')).toBe(false)
+    expect(isValidNpmPackage('my!pkg')).toBe(false)
+  })
+
+  it('trims whitespace before validating', () => {
+    expect(isValidNpmPackage('  lodash  ')).toBe(true)
+  })
+})
+
+describe('buildUnpkgPackagePath', () => {
+  it('encodes a simple package name', () => {
+    expect(buildUnpkgPackagePath('lodash')).toBe('lodash')
+  })
+
+  it('encodes a scoped package', () => {
+    expect(buildUnpkgPackagePath('@babel/core')).toBe('@babel%2Fcore')
+  })
+
+  it('trims whitespace', () => {
+    expect(buildUnpkgPackagePath('  lodash  ')).toBe('lodash')
+  })
+
+  it('throws for invalid package names', () => {
+    expect(() => buildUnpkgPackagePath('INVALID!')).toThrow('Invalid package name')
+  })
+})
+
+describe('fetchNpmSource', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('throws for invalid package names', async () => {
+    await expect(fetchNpmSource('INVALID!')).rejects.toThrow('Invalid package name')
+  })
+
+  it('throws when package is not found (404)', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 })
+    await expect(fetchNpmSource('no-such-pkg-xyzxyz')).rejects.toThrow('Package not found on npm')
+  })
+
+  it('throws when unpkg returns a non-404 error', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 })
+    await expect(fetchNpmSource('lodash')).rejects.toThrow('unpkg returned 500')
+  })
+
+  it('returns content on success', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: async () => 'console.log("hi")',
+    })
+    const result = await fetchNpmSource('lodash')
+    expect(result).toBe('console.log("hi")')
+  })
+
+  it('throws when content exceeds 100 000 characters', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: async () => 'x'.repeat(100_001),
+    })
+    await expect(fetchNpmSource('lodash')).rejects.toThrow('File too large')
+  })
+
+  it('accepts an optional version parameter', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: async () => '// v1',
+    })
+    const result = await fetchNpmSource('lodash', '4.17.21')
+    expect(result).toBe('// v1')
+    const url = (global.fetch as jest.Mock).mock.calls[0][0] as string
+    expect(url).toContain('4.17.21')
+  })
+})

--- a/lib/__tests__/recentScans.test.ts
+++ b/lib/__tests__/recentScans.test.ts
@@ -1,0 +1,132 @@
+import { addRecent, getRecent, truncateLabel } from '../recentScans'
+import type { RecentScan } from '../recentScans'
+
+const STORAGE_KEY = 'sg_recent_scans'
+
+const mockLocalStorage = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: jest.fn((key: string) => store[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => { store[key] = value }),
+    removeItem: jest.fn((key: string) => { delete store[key] }),
+    clear: () => { store = {} },
+  }
+})()
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', { value: global, writable: true })
+  Object.defineProperty(global, 'localStorage', { value: mockLocalStorage, writable: true })
+})
+
+beforeEach(() => {
+  mockLocalStorage.clear()
+  jest.clearAllMocks()
+})
+
+describe('getRecent', () => {
+  it('returns empty array when nothing stored', () => {
+    expect(getRecent()).toEqual([])
+  })
+
+  it('returns parsed array from localStorage', () => {
+    const data: RecentScan[] = [{ type: 'github', value: 'owner/repo', timestamp: 1 }]
+    mockLocalStorage.getItem.mockReturnValueOnce(JSON.stringify(data))
+    expect(getRecent()).toEqual(data)
+  })
+
+  it('returns empty array for malformed JSON', () => {
+    mockLocalStorage.getItem.mockReturnValueOnce('not-json')
+    expect(getRecent()).toEqual([])
+  })
+
+  it('returns empty array when parsed value is not an array', () => {
+    mockLocalStorage.getItem.mockReturnValueOnce(JSON.stringify({ type: 'code' }))
+    expect(getRecent()).toEqual([])
+  })
+})
+
+describe('addRecent', () => {
+  it('stores a new entry', () => {
+    addRecent('github', 'owner/repo')
+    const stored: RecentScan[] = JSON.parse(mockLocalStorage.setItem.mock.calls[0][1])
+    expect(stored[0].type).toBe('github')
+    expect(stored[0].value).toBe('owner/repo')
+  })
+
+  it('deduplicates by type + value', () => {
+    addRecent('github', 'owner/repo')
+    addRecent('github', 'owner/repo')
+    const stored: RecentScan[] = JSON.parse(mockLocalStorage.setItem.mock.calls[1][1])
+    expect(stored).toHaveLength(1)
+  })
+
+  it('puts the new entry at the front', () => {
+    addRecent('github', 'repo-a')
+    addRecent('github', 'repo-b')
+    const stored: RecentScan[] = JSON.parse(mockLocalStorage.setItem.mock.calls[1][1])
+    expect(stored[0].value).toBe('repo-b')
+    expect(stored[1].value).toBe('repo-a')
+  })
+
+  it('caps at 5 entries', () => {
+    for (let i = 0; i < 7; i++) addRecent('code', `code-${i}`)
+    const stored: RecentScan[] = JSON.parse(mockLocalStorage.setItem.mock.calls.at(-1)![1])
+    expect(stored).toHaveLength(5)
+  })
+
+  it('moves an existing entry to the top on re-add', () => {
+    addRecent('github', 'a')
+    addRecent('github', 'b')
+    addRecent('github', 'a')
+    const stored: RecentScan[] = JSON.parse(mockLocalStorage.setItem.mock.calls.at(-1)![1])
+    expect(stored[0].value).toBe('a')
+    expect(stored).toHaveLength(2)
+  })
+})
+
+describe('truncateLabel', () => {
+  const scan = (type: RecentScan['type'], value: string): RecentScan => ({ type, value, timestamp: 0 })
+
+  it('returns short contractId unchanged', () => {
+    const s = scan('contractId', 'short-id')
+    expect(truncateLabel(s)).toBe('short-id')
+  })
+
+  it('truncates long contractId with start + end', () => {
+    const value = 'A'.repeat(21) + 'B'.repeat(10)
+    const s = scan('contractId', value)
+    const result = truncateLabel(s)
+    expect(result).toContain('...')
+    expect(result.startsWith('A'.repeat(20))).toBe(true)
+    expect(result.endsWith('B'.repeat(10))).toBe(true)
+  })
+
+  it('returns short github URL unchanged', () => {
+    const s = scan('github', 'owner/repo')
+    expect(truncateLabel(s)).toBe('owner/repo')
+  })
+
+  it('truncates long github URL with trailing ellipsis', () => {
+    const s = scan('github', 'a'.repeat(50))
+    const result = truncateLabel(s)
+    expect(result.endsWith('...')).toBe(true)
+    expect(result.length).toBe(40)
+  })
+
+  it('returns first line for code type', () => {
+    const s = scan('code', 'line one\nline two')
+    expect(truncateLabel(s)).toBe('line one')
+  })
+
+  it('truncates long first code line', () => {
+    const s = scan('code', 'x'.repeat(50))
+    const result = truncateLabel(s)
+    expect(result.endsWith('...')).toBe(true)
+    expect(result.length).toBe(40)
+  })
+
+  it('returns short code value unchanged', () => {
+    const s = scan('code', 'short')
+    expect(truncateLabel(s)).toBe('short')
+  })
+})

--- a/lib/__tests__/wordCloud.test.ts
+++ b/lib/__tests__/wordCloud.test.ts
@@ -1,0 +1,94 @@
+import { tokenize, extractTerms } from '../wordCloud'
+import type { Finding } from '@/types/findings'
+
+describe('tokenize', () => {
+  it('splits on non-alphanumeric characters', () => {
+    expect(tokenize('hello world')).toContain('hello')
+    expect(tokenize('hello world')).toContain('world')
+  })
+
+  it('lowercases all tokens', () => {
+    expect(tokenize('Hello WORLD')).toEqual(expect.arrayContaining(['hello', 'world']))
+  })
+
+  it('filters out tokens shorter than 3 characters', () => {
+    expect(tokenize('a bb ccc')).not.toContain('a')
+    expect(tokenize('a bb ccc')).not.toContain('bb')
+    expect(tokenize('a bb ccc')).toContain('ccc')
+  })
+
+  it('filters out stop words', () => {
+    expect(tokenize('the quick brown fox')).not.toContain('the')
+    expect(tokenize('the quick brown fox')).toContain('quick')
+    expect(tokenize('the quick brown fox')).toContain('brown')
+  })
+
+  it('preserves hyphens and underscores in tokens', () => {
+    const result = tokenize('my-func my_var')
+    expect(result).toContain('my-func')
+    expect(result).toContain('my_var')
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(tokenize('')).toEqual([])
+  })
+
+  it('strips punctuation', () => {
+    const result = tokenize('buffer!overflow')
+    expect(result).toContain('buffer')
+    expect(result).toContain('overflow')
+  })
+})
+
+const makeFinding = (check_name: string, description: string): Finding => ({
+  check_name,
+  severity: 'High',
+  file_path: 'src/lib.rs',
+  line: 1,
+  function_name: 'fn_name',
+  description,
+})
+
+describe('extractTerms', () => {
+  it('returns an empty object for no findings', () => {
+    expect(extractTerms([])).toEqual({})
+  })
+
+  it('counts tokens from check_name with weight 3', () => {
+    const findings = [makeFinding('reentrancy', '')]
+    const result = extractTerms(findings)
+    expect(result['reentrancy']).toBe(3)
+  })
+
+  it('counts tokens from description with weight 1', () => {
+    const findings = [makeFinding('', 'overflow detected')]
+    const result = extractTerms(findings)
+    expect(result['overflow']).toBe(1)
+    expect(result['detected']).toBe(1)
+  })
+
+  it('accumulates counts across multiple findings', () => {
+    const findings = [
+      makeFinding('reentrancy', 'reentrancy risk'),
+      makeFinding('reentrancy', ''),
+    ]
+    const result = extractTerms(findings)
+    expect(result['reentrancy']).toBe(3 + 1 + 3) // desc + check_name×2
+  })
+
+  it('returns at most 30 entries', () => {
+    const findings = Array.from({ length: 40 }, (_, i) =>
+      makeFinding(`term${i}term`, '')
+    )
+    expect(Object.keys(extractTerms(findings)).length).toBeLessThanOrEqual(30)
+  })
+
+  it('sorts entries by frequency descending', () => {
+    const findings = [
+      makeFinding('reentrancy', 'overflow'),
+      makeFinding('reentrancy', ''),
+    ]
+    const entries = Object.entries(extractTerms(findings))
+    expect(entries[0][0]).toBe('reentrancy')
+  })
+})

--- a/lib/npm.ts
+++ b/lib/npm.ts
@@ -13,7 +13,7 @@ export function isValidNpmPackage(packageName: string): boolean {
   return NPM_PACKAGE_NAME_RE.test(trimmed)
 }
 
-function buildUnpkgPackagePath(packageName: string): string {
+export function buildUnpkgPackagePath(packageName: string): string {
   const trimmed = packageName.trim()
   const scopedMatch = trimmed.match(/^@([^/]+)\/(.+)$/)
 

--- a/lib/wordCloud.ts
+++ b/lib/wordCloud.ts
@@ -14,7 +14,7 @@ const STOP_WORDS = new Set([
   'up', 'down', 'while', 'also', 'only', 'same', 'own', 'your', 'their',
 ])
 
-function tokenize(text: string): string[] {
+export function tokenize(text: string): string[] {
   return text
     .toLowerCase()
     .replace(/[^a-z0-9_-]/g, ' ')


### PR DESCRIPTION
## Summary

- Set up Jest + ts-jest with `@/` path alias support (`jest.config.js`)
- Exported `buildUnpkgPackagePath` (lib/npm.ts) and `tokenize` (lib/wordCloud.ts) so they can be directly unit-tested
- Added `\"test\": \"jest\"` script to `package.json`

## Test coverage added

| File | Functions covered |
|------|-------------------|
| `lib/npm.ts` | `isValidNpmPackage`, `buildUnpkgPackagePath`, `fetchNpmSource` |
| `lib/wordCloud.ts` | `tokenize`, `extractTerms` |
| `lib/history.ts` | `addScanRecord`, `getScanHistory`, `getById`, `clearScanHistory` |
| `lib/recentScans.ts` | `addRecent`, `getRecent`, `truncateLabel` |

`localStorage` is mocked in the history and recentScans suites. `fetch` is mocked for the npm fetch tests.

## Closes

Closes #249
Closes #250
Closes #251
Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)