### PR TITLE
feat: add scan score trend chart to analytics page

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { getAllScanHistory } from '@/lib/history'
-import { computeAnalytics, checkTrend, allCheckNames, type Analytics } from '@/lib/analytics'
+import { computeAnalytics, checkTrend, allCheckNames, scoreTrend, type Analytics } from '@/lib/analytics'
 import type { ContractScanRecord } from '@/types/stellar'
 import ThemeToggle from '@/components/ThemeToggle'
 import CheckTrendChart from '@/components/CheckTrendChart'
@@ -33,6 +33,9 @@ export default function AnalyticsPage() {
   }
 
   const isEmpty = records.length < MIN_RECORDS
+
+  // Compute security score trend data (average findings per scan per day)
+  const scoreTrendData = scoreTrend(records)
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -79,6 +82,16 @@ export default function AnalyticsPage() {
               <StatCard label="Total medium" value={analytics.totalFindings.medium} color="text-amber-400" />
             </div>
 
+            {/* Security score trend chart */}
+            <div className="mb-6 rounded-xl border border-[var(--border)] bg-[#12151f] p-6">
+              <h2 className="mb-4 text-sm font-semibold text-slate-300">Security score trend over time</h2>
+              {scoreTrendData.length < 2 ? (
+                <p className="text-sm text-slate-500">Not enough data points to show a trend.</p>
+              ) : (
+                <CheckTrendChart data={scoreTrendData} checkName="Security Score" />
+              )}
+            </div>
+
             {/* Top checks bar chart */}
             <div className="rounded-xl border border-[var(--border)] bg-[#12151f] p-6">
               <h2 className="mb-5 text-sm font-semibold text-slate-300">Top 5 most frequent checks</h2>
@@ -115,6 +128,16 @@ export default function AnalyticsPage() {
                   )}
                 </div>
               )
+            })()}
+          </>
+        )}
+      </main>
+
+      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
+        Soroban Guard · Veritas Vaults Network
+      </footer>
+    </div>
+  )
             })()}
           </>
         )}

--- a/components/CheckTrendChart.tsx
+++ b/components/CheckTrendChart.tsx
@@ -28,12 +28,11 @@ export default function CheckTrendChart({ data, checkName }: Props) {
             axisLine={false}
             tickLine={false}
           />
-          <YAxis
-            allowDecimals={false}
-            tick={{ fill: '#64748b', fontSize: 11 }}
-            axisLine={false}
-            tickLine={false}
-          />
+        <YAxis
+          tick={{ fill: '#64748b', fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+        />
           <Tooltip
             contentStyle={{ background: '#1a1d27', border: '1px solid #2a2d3a', borderRadius: 8 }}
             labelStyle={{ color: '#e2e8f0', marginBottom: 4 }}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -67,3 +67,29 @@ export function allCheckNames(records: ContractScanRecord[]): string[] {
   }
   return Array.from(names).sort()
 }
+
+export function scoreTrend(records: ContractScanRecord[]): { date: string; count: number }[] {
+  // Group by day (YYYY-MM-DD)
+  const daily: Record<string, { total: number; count: number }> = {}
+
+  for (const record of records) {
+    const date = record.scannedAt.slice(0, 10) // YYYY-MM-DD
+    if (!daily[date]) {
+      daily[date] = { total: 0, count: 0 }
+    }
+    daily[date].total += record.findingCount
+    daily[date].count++
+  }
+
+  // Compute average and convert to array
+  const result: { date: string; count: number }[] = Object.entries(daily).map(
+    ([date, { total, count }]) => ({
+      date,
+      count: Math.round((total / count) * 10) / 10, // Keep one decimal place
+    })
+  )
+
+  // Sort by date ascending
+  result.sort((a, b) => a.date.localeCompare(b.date))
+  return result
+}


### PR DESCRIPTION
Added a line chart to app/analytics/page.tsx showing the security score trend over time using lib/analytics.ts data.
closes #313