### PR TITLE
feat: add Horizon transaction history for scanned contracts

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -29,6 +29,8 @@ import GithubExportModal from '@/components/GithubExportModal'
 import JiraExportModal from '@/components/JiraExportModal'
 import NotionExportModal from '@/components/NotionExportModal'
 import ResultsQRCode from '@/components/ResultsQRCode'
+import { fetchContractTransactions, isValidContractId, type ContractTransaction } from '@/lib/stellar'
+import { NETWORKS } from '@/types/stellar'
 
 export default function ResultsClient() {
   const router = useRouter()
@@ -47,6 +49,7 @@ export default function ResultsClient() {
   const [groupView, setGroupView] = useState<'flat' | 'function'>('flat')
   const [navIndex, setNavIndex] = useState<number | null>(null)
   const [showShortcutsModal, setShowShortcutsModal] = useState(false)
+  const [contractTxs, setContractTxs] = useState<ContractTransaction[]>([])
   const hasSource = Boolean(scanSource)
 
   useEffect(() => {
@@ -113,6 +116,14 @@ export default function ResultsClient() {
       setPrevFindings(prev.findings as Finding[])
     }
   }, [findings])
+
+  useEffect(() => {
+    const source = sessionStorage.getItem('sg_last_scan_source') ?? sessionStorage.getItem('sg_scan_source')
+    if (!source || !isValidContractId(source)) return
+
+    const network = NETWORKS[sessionStorage.getItem('sg_network') ?? 'testnet'] ?? NETWORKS.testnet
+    fetchContractTransactions(source, network).then(setContractTxs)
+  }, [])
 
   function handleScanAnother() {
     sessionStorage.removeItem('sg_findings')
@@ -602,6 +613,47 @@ export default function ResultsClient() {
               </>
             )}
           </div>
+        )}
+
+        {contractTxs.length > 0 && (
+          <section className="mt-10" aria-labelledby="tx-history-heading">
+            <h2 id="tx-history-heading" className="mb-3 text-sm font-semibold text-slate-400">
+              Recent Transactions
+            </h2>
+            <div className="overflow-hidden rounded-xl border border-[var(--border)]">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)] text-xs text-slate-500">
+                    <th className="px-4 py-2 text-left font-medium">Hash</th>
+                    <th className="px-4 py-2 text-left font-medium">Date</th>
+                    <th className="px-4 py-2 text-right font-medium">Ops</th>
+                    <th className="px-4 py-2 text-right font-medium">Fee (stroops)</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[var(--border)]">
+                  {contractTxs.map(tx => (
+                    <tr key={tx.id} className="bg-[var(--bg)] transition hover:bg-[var(--bg-secondary)]">
+                      <td className="px-4 py-2 font-mono text-xs text-indigo-400">
+                        <a
+                          href={`https://stellar.expert/explorer/testnet/tx/${tx.hash}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:underline"
+                        >
+                          {tx.hash.slice(0, 12)}…
+                        </a>
+                      </td>
+                      <td className="px-4 py-2 text-slate-400">
+                        {new Date(tx.created_at).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-2 text-right text-slate-300">{tx.operation_count}</td>
+                      <td className="px-4 py-2 text-right text-slate-300">{tx.fee_charged}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
         )}
       </main>
 

--- a/lib/stellar.ts
+++ b/lib/stellar.ts
@@ -190,6 +190,40 @@ export async function fetchContractsByAccount(
   }
 }
 
+// ── Contract transaction history ─────────────────────────────────────────────
+
+export interface ContractTransaction {
+  id: string
+  hash: string
+  created_at: string
+  operation_count: number
+  fee_charged: string
+}
+
+/**
+ * Fetch the 10 most recent transactions for a contract from Horizon.
+ * Uses the /accounts/:contract_id/transactions endpoint.
+ * Returns an empty array if the contract has no transactions or on error.
+ */
+export async function fetchContractTransactions(
+  contractId: string,
+  network: StellarNetwork,
+): Promise<ContractTransaction[]> {
+  if (!isValidContractId(contractId)) return []
+
+  try {
+    const url = `${network.horizonUrl}/accounts/${contractId}/transactions?limit=10&order=desc`
+    const res = await fetch(url, { headers: { Accept: 'application/json' } })
+    if (!res.ok) return []
+    const data = (await res.json()) as {
+      _embedded?: { records?: ContractTransaction[] }
+    }
+    return data._embedded?.records ?? []
+  } catch {
+    return []
+  }
+}
+
 /**
  * Fetch contract metadata including WASM hash, creation date, and creator.
  * Note: Creator is not available via current APIs and will return null.


### PR DESCRIPTION
## Summary

After scanning a contract ID (C-address), the results page now fetches and displays the 10 most recent transactions for that contract from the Horizon REST API.

## Changes

### `lib/stellar.ts`
- Added `ContractTransaction` interface (id, hash, created_at, operation_count, fee_charged)
- Added `fetchContractTransactions(contractId, network)` helper that calls `GET /accounts/:contract_id/transactions?limit=10&order=desc` on Horizon and returns the records array

### `app/results/ResultsClient.tsx`
- Imported `fetchContractTransactions`, `isValidContractId`, `ContractTransaction` from `lib/stellar` and `NETWORKS` from `types/stellar`
- Added `contractTxs` state
- Added `useEffect` that fires on mount: reads the scan source from sessionStorage, validates it is a C-address, resolves the network, and fetches transactions
- Added a "Recent Transactions" table section inside `<main>` that renders when `contractTxs.length > 0`, showing hash (linked to stellar.expert), date, operation count, and fee

## Testing
- Only shown when the scanned source is a valid Soroban contract ID (C-address)
- Silently no-ops for source code / GitHub URL scans
- No new TypeScript errors introduced (pre-existing errors in the file are unrelated)

closes #294