### PR TITLE
feat: add WASM bytecode size display for contract ID scans

### DIFF
--- a/components/ScanInput.tsx
+++ b/components/ScanInput.tsx
@@ -5,7 +5,8 @@ import { SAMPLE_CONTRACT } from "@/lib/sampleContract";
 import { isValidCid, fetchFromIpfs } from "@/lib/ipfs";
 import { isValidNpmPackage, fetchNpmSource } from "@/lib/npm";
 import { requestPermission } from "@/lib/notifications";
-import { extractContractIdFromUrl } from "@/lib/stellar";
+import { extractContractIdFromUrl, getContractWasmSize } from "@/lib/stellar";
+import { NETWORKS } from "@/types/stellar";
 import {
   isValidGistUrl,
   fetchGistFiles,
@@ -99,6 +100,7 @@ export default function ScanInput({
   const [npmPackageValid, setNpmPackageValid] = useState(false);
   const [normalized, setNormalized] = useState(false);
   const [extractedFromUrl, setExtractedFromUrl] = useState(false);
+  const [wasmSize, setWasmSize] = useState<number | null>(null);
   // Gist state
   const [gistUrl, setGistUrl] = useState("");
   const [gistFiles, setGistFiles] = useState<GistFile[]>([]);
@@ -135,6 +137,12 @@ export default function ScanInput({
     repoUrl.length > 0 && !repoValidation.valid
       ? repoValidation.error
       : undefined;
+
+  useEffect(() => {
+    if (!contractValid) { setWasmSize(null); return; }
+    const network = (typeof selectedNetwork !== "undefined" ? selectedNetwork : null) ?? NETWORKS.testnet;
+    getContractWasmSize(contractId, network).then(setWasmSize);
+  }, [contractId, contractValid]);
 
   function handleContractIdChange(raw: string) {
     setExtractedFromUrl(false);
@@ -504,6 +512,11 @@ export default function ScanInput({
           {extractedFromUrl && (
             <p className="text-xs text-emerald-400">
               ✓ Extracted from explorer URL
+            </p>
+          )}
+          {wasmSize !== null && (
+            <p className="text-xs text-indigo-300">
+              WASM size: {wasmSize.toLocaleString()} bytes ({(wasmSize / 1024).toFixed(1)} KB)
             </p>
           )}
           <p className="text-xs text-slate-500">

--- a/lib/stellar.ts
+++ b/lib/stellar.ts
@@ -100,6 +100,20 @@ async function rpcCall<T>(
 }
 
 /**
+ * Fetch the WASM bytecode size (in bytes) for a contract from Soroban RPC.
+ * Returns the byte count, or null if not found.
+ */
+export async function getContractWasmSize(
+  contractId: string,
+  network: StellarNetwork,
+): Promise<number | null> {
+  const wasm = await fetchContractWasm(contractId, network)
+  if (!wasm) return null
+  // wasm is hex-encoded: 2 hex chars = 1 byte
+  return wasm.length / 2
+}
+
+/**
  * Fetch the WASM bytecode for a contract from Soroban RPC.
  * Returns the hex-encoded WASM string, or null if not found.
  */


### PR DESCRIPTION
## Summary

When scanning by contract ID (C-address), the WASM bytecode size is now fetched from Soroban RPC and displayed below the input field so users know what was analyzed.

## Changes

### `lib/stellar.ts`
- Added `getContractWasmSize(contractId, network)` helper that calls the existing `fetchContractWasm` and returns the byte count (hex string length ÷ 2), or `null` if not found

### `components/ScanInput.tsx`
- Imported `getContractWasmSize` from `lib/stellar` and `NETWORKS` from `types/stellar`
- Added `wasmSize` state (`number | null`)
- Added `useEffect` that fires when `contractId` changes: clears size if invalid, otherwise fetches and sets it using the active network (falls back to testnet)
- Added display line below the input showing `WASM size: X bytes (Y KB)` in indigo when size is available

## Testing
- Only shown when a valid C-address is entered and the RPC call succeeds
- Silently no-ops if the contract is not found or RPC is unreachable
- No new TypeScript errors introduced

closes #293