### PR TITLE
feat: add Telegram/Discord/Slack notify buttons and env validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ blob-report/
 playwright/.cache/
 **/__snapshots__/
 
+# jest / vitest
+coverage/
+*.snap
+
 # editor
 .idea/
 .vscode/settings.json

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,9 @@ import { WalletProvider } from '@/lib/WalletContext'
 import { ToastProvider } from '@/lib/toast'
 import ToastContainer from '@/components/ToastContainer'
 import ErrorBoundary from '@/components/ErrorBoundary'
+import { validateEnv } from '@/lib/env'
+
+validateEnv()
 
 export const metadata: Metadata = {
   title: 'Soroban Guard — Smart Contract Security Scanner',

--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -19,15 +19,15 @@ import FindingsWordCloud from '@/components/FindingsWordCloud'
 import EmptyState from '@/components/EmptyState'
 import SeverityBadge from '@/components/SeverityBadge'
 import SeverityDonut from '@/components/SeverityDonut'
-import FindingsSkeleton from '@/components/FindingsSkeleton'
 import ThemeToggle from '@/components/ThemeToggle'
 import { generatePdfReport } from '@/lib/pdfReport'
 import { calculateScore } from '@/lib/score'
-import { useToast } from '@/lib/toast'
-import { useWallet } from '@/lib/WalletContext'
 import GithubExportModal from '@/components/GithubExportModal'
 import JiraExportModal from '@/components/JiraExportModal'
 import NotionExportModal from '@/components/NotionExportModal'
+import TelegramNotifyModal from '@/components/TelegramNotifyModal'
+import DiscordNotifyModal from '@/components/DiscordNotifyModal'
+import SlackNotifyModal from '@/components/SlackNotifyModal'
 import ResultsQRCode from '@/components/ResultsQRCode'
 
 export default function ResultsClient() {
@@ -47,7 +47,16 @@ export default function ResultsClient() {
   const [groupView, setGroupView] = useState<'flat' | 'function'>('flat')
   const [navIndex, setNavIndex] = useState<number | null>(null)
   const [showShortcutsModal, setShowShortcutsModal] = useState(false)
-  const hasSource = Boolean(scanSource)
+  const [scanSource, setScanSource] = useState<string | null>(null)
+  const [resultsUrl, setResultsUrl] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [isRescanning, setIsRescanning] = useState(false)
+  const [duration, setDuration] = useState<string | null>(null)
+  const [attestationTxHash, setAttestationTxHash] = useState<string | null>(null)
+  const [attestationExplorerUrl, setAttestationExplorerUrl] = useState<string | null>(null)
+  const [showTelegramModal, setShowTelegramModal] = useState(false)
+  const [showDiscordModal, setShowDiscordModal] = useState(false)
+  const [showSlackModal, setShowSlackModal] = useState(false)
 
   useEffect(() => {
     const storedFindings = sessionStorage.getItem('sg_findings')
@@ -75,6 +84,13 @@ export default function ResultsClient() {
       return
     }
 
+    const source = sessionStorage.getItem('sg_last_scan_source') ?? sessionStorage.getItem('sg_scan_source')
+    if (source) setScanSource(source)
+
+    const d = sessionStorage.getItem('sg_scan_duration')
+    if (d) setDuration(d)
+  }, [router, searchParams])
+
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
@@ -99,7 +115,9 @@ export default function ResultsClient() {
         }
       }
     }
-  }, [router, searchParams])
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [findings, navIndex])
 
   useEffect(() => {
     if (findings == null) return
@@ -225,7 +243,7 @@ export default function ResultsClient() {
     )
   }
 
-  const counts: Record<Severity, number> = { Critical: 0, High: 0, Medium: 0, Low: 0 }
+  const counts: Record<Severity, number> = { Critical: 0, High: 0, Medium: 0, Low: 0, Info: 0 }
   for (const finding of findings) counts[finding.severity]++
 
   const q = searchQuery.toLowerCase()
@@ -337,6 +355,30 @@ export default function ResultsClient() {
                 className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
               >
                 Export to Jira
+              </button>
+            )}
+            {findings.length > 0 && (
+              <button
+                onClick={() => setShowTelegramModal(true)}
+                className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+              >
+                Notify Telegram
+              </button>
+            )}
+            {findings.length > 0 && (
+              <button
+                onClick={() => setShowDiscordModal(true)}
+                className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+              >
+                Notify Discord
+              </button>
+            )}
+            {findings.length > 0 && (
+              <button
+                onClick={() => setShowSlackModal(true)}
+                className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+              >
+                Notify Slack
               </button>
             )}
             {getEmbedToken() && (
@@ -628,6 +670,15 @@ export default function ResultsClient() {
       )}
       {showNotionModal && (
         <NotionExportModal findings={findings} onClose={() => setShowNotionModal(false)} />
+      )}
+      {showTelegramModal && (
+        <TelegramNotifyModal findings={findings} source={scanSource ?? ''} onClose={() => setShowTelegramModal(false)} />
+      )}
+      {showDiscordModal && (
+        <DiscordNotifyModal findings={findings} source={scanSource ?? ''} onClose={() => setShowDiscordModal(false)} />
+      )}
+      {showSlackModal && (
+        <SlackNotifyModal findings={findings} source={scanSource ?? ''} onClose={() => setShowSlackModal(false)} />
       )}
       {showShortcutsModal && (
         <div

--- a/components/DiscordNotifyModal.tsx
+++ b/components/DiscordNotifyModal.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useId, useState } from 'react'
+import type { Finding } from '@/types/findings'
+import { postToDiscord } from '@/lib/discord'
+import { useFocusTrap } from '@/lib/useFocusTrap'
+
+interface Props {
+  findings: Finding[]
+  source: string
+  onClose: () => void
+}
+
+export default function DiscordNotifyModal({ findings, source, onClose }: Props) {
+  const [webhookUrl, setWebhookUrl] = useState('')
+  const [status, setStatus] = useState<'idle' | 'sending' | 'done' | 'error'>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const titleId = useId()
+  const dialogRef = useFocusTrap<HTMLDivElement>(onClose)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus('sending')
+    setError(null)
+    try {
+      await postToDiscord(webhookUrl.trim(), findings, source)
+      setStatus('done')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+      role="presentation"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-md rounded-2xl border border-[#2a2d3a] bg-[#0e1117] p-6 shadow-xl"
+      >
+        <div className="mb-5 flex items-center justify-between">
+          <h2 id={titleId} className="text-base font-semibold text-white">Send to Discord</h2>
+          <button onClick={onClose} aria-label="Close dialog" className="rounded text-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {status === 'done' ? (
+          <div className="space-y-3">
+            <p className="text-sm text-emerald-400">✓ Scan results sent to Discord</p>
+            <button onClick={onClose} className="w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500">
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <input
+              required
+              value={webhookUrl}
+              onChange={e => setWebhookUrl(e.target.value)}
+              placeholder="Discord Webhook URL"
+              disabled={status === 'sending'}
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+            />
+            <p className="text-xs text-slate-500">Webhook URL is never stored or sent to our servers.</p>
+            {error && <p className="text-xs text-rose-400">{error}</p>}
+            <button
+              type="submit"
+              disabled={status === 'sending'}
+              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            >
+              {status === 'sending' ? 'Sending…' : 'Send notification'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/SlackNotifyModal.tsx
+++ b/components/SlackNotifyModal.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useId, useState } from 'react'
+import type { Finding } from '@/types/findings'
+import { postToSlack } from '@/lib/slack'
+import { useFocusTrap } from '@/lib/useFocusTrap'
+
+interface Props {
+  findings: Finding[]
+  source: string
+  onClose: () => void
+}
+
+export default function SlackNotifyModal({ findings, source, onClose }: Props) {
+  const [webhookUrl, setWebhookUrl] = useState('')
+  const [status, setStatus] = useState<'idle' | 'sending' | 'done' | 'error'>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const titleId = useId()
+  const dialogRef = useFocusTrap<HTMLDivElement>(onClose)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus('sending')
+    setError(null)
+    try {
+      await postToSlack(webhookUrl.trim(), findings, source)
+      setStatus('done')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+      role="presentation"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-md rounded-2xl border border-[#2a2d3a] bg-[#0e1117] p-6 shadow-xl"
+      >
+        <div className="mb-5 flex items-center justify-between">
+          <h2 id={titleId} className="text-base font-semibold text-white">Send to Slack</h2>
+          <button onClick={onClose} aria-label="Close dialog" className="rounded text-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {status === 'done' ? (
+          <div className="space-y-3">
+            <p className="text-sm text-emerald-400">✓ Scan results sent to Slack</p>
+            <button onClick={onClose} className="w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500">
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <input
+              required
+              value={webhookUrl}
+              onChange={e => setWebhookUrl(e.target.value)}
+              placeholder="Slack Incoming Webhook URL"
+              disabled={status === 'sending'}
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+            />
+            <p className="text-xs text-slate-500">Webhook URL is never stored or sent to our servers.</p>
+            {error && <p className="text-xs text-rose-400">{error}</p>}
+            <button
+              type="submit"
+              disabled={status === 'sending'}
+              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            >
+              {status === 'sending' ? 'Sending…' : 'Send notification'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/TelegramNotifyModal.tsx
+++ b/components/TelegramNotifyModal.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useId, useState } from 'react'
+import type { Finding } from '@/types/findings'
+import { postToTelegram } from '@/lib/telegram'
+import { useFocusTrap } from '@/lib/useFocusTrap'
+
+interface Props {
+  findings: Finding[]
+  source: string
+  onClose: () => void
+}
+
+export default function TelegramNotifyModal({ findings, source, onClose }: Props) {
+  const [botToken, setBotToken] = useState('')
+  const [chatId, setChatId] = useState('')
+  const [status, setStatus] = useState<'idle' | 'sending' | 'done' | 'error'>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const titleId = useId()
+  const dialogRef = useFocusTrap<HTMLDivElement>(onClose)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus('sending')
+    setError(null)
+    try {
+      await postToTelegram(botToken.trim(), chatId.trim(), findings, source)
+      setStatus('done')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+      role="presentation"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-md rounded-2xl border border-[#2a2d3a] bg-[#0e1117] p-6 shadow-xl"
+      >
+        <div className="mb-5 flex items-center justify-between">
+          <h2 id={titleId} className="text-base font-semibold text-white">Send to Telegram</h2>
+          <button onClick={onClose} aria-label="Close dialog" className="rounded text-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {status === 'done' ? (
+          <div className="space-y-3">
+            <p className="text-sm text-emerald-400">✓ Scan results sent to Telegram</p>
+            <button onClick={onClose} className="w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500">
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <input
+              required
+              type="password"
+              value={botToken}
+              onChange={e => setBotToken(e.target.value)}
+              placeholder="Bot Token (from @BotFather)"
+              disabled={status === 'sending'}
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+            />
+            <input
+              required
+              value={chatId}
+              onChange={e => setChatId(e.target.value)}
+              placeholder="Chat ID (e.g. -1001234567890)"
+              disabled={status === 'sending'}
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+            />
+            <p className="text-xs text-slate-500">Token is never stored or sent to our servers.</p>
+            {error && <p className="text-xs text-rose-400">{error}</p>}
+            <button
+              type="submit"
+              disabled={status === 'sending'}
+              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            >
+              {status === 'sending' ? 'Sending…' : 'Send notification'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,25 @@
+/**
+ * Validates required environment variables at startup.
+ * Logs a warning for any that are missing or malformed.
+ * Safe to call in both server and client contexts.
+ */
+export function validateEnv(): void {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL
+
+  if (!apiUrl) {
+    console.warn(
+      '[Soroban Guard] NEXT_PUBLIC_API_URL is not set. Defaulting to http://localhost:3001. ' +
+        'Set this variable in .env.local for production use.',
+    )
+    return
+  }
+
+  try {
+    new URL(apiUrl)
+  } catch {
+    console.warn(
+      `[Soroban Guard] NEXT_PUBLIC_API_URL is malformed: "${apiUrl}". ` +
+        'Expected a valid URL (e.g. https://api.example.com).',
+    )
+  }
+}


### PR DESCRIPTION
- Add TelegramNotifyModal, DiscordNotifyModal, SlackNotifyModal components
- Wire notify buttons into ResultsClient export menu
- Fix duplicate imports and missing state vars in ResultsClient
- Fix broken useEffect (missing closing brace and event listeners)
- Add lib/env.ts with validateEnv() for startup env checks
- Call validateEnv() from app/layout.tsx
- Update .gitignore: add coverage/ and *.snap exclusions

Closes #316 
closes #317 
closes #318 
closes #319 