### PR TITLE
feat: add e2e tests for CSV/JSON/Markdown export (#235)

### DIFF
--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import type { Finding, Severity } from '@/types/findings'
 import { decodeFindingsParam, encodeWorkspace } from '@/lib/share'
 import { exportEmail } from '@/lib/export'
+import { exportJson, exportCsv, downloadMarkdown } from '@/lib/export'
 import { exportSarif } from '@/lib/sarif'
 import { getAllScanHistory } from '@/lib/history'
 import { diffFindings } from '@/lib/diffFindings'
@@ -308,6 +309,24 @@ export default function ResultsClient() {
               className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
             >
               Download PDF
+            </button>
+            <button
+              onClick={() => exportJson(findings)}
+              className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+            >
+              Download JSON
+            </button>
+            <button
+              onClick={() => exportCsv(findings)}
+              className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+            >
+              Download CSV
+            </button>
+            <button
+              onClick={() => downloadMarkdown(findings, { source: scanSource ?? 'Unknown', scannedAt: new Date().toISOString() })}
+              className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm text-slate-400 transition hover:text-white"
+            >
+              Download Markdown
             </button>
             {findings.length > 0 && (
               <button

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs/promises'
+
+function mockFetch(page: any, body: any) {
+  return page.addInitScript(`
+    (() => {
+      const originalFetch = window.fetch;
+      window.fetch = async (input, init) => {
+        const url = typeof input === 'string' ? input : input.url;
+        if (url.includes('/scan') && init?.method === 'POST') {
+          return new Response(JSON.stringify(${JSON.stringify(body)}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }
+        return originalFetch(input, init);
+      };
+    })();
+  `)
+}
+
+const mockFindings = {
+  findings: [
+    { check_name: 'export-check', severity: 'Medium', file_path: 'src/lib.rs', line: 2, function_name: 'foo', description: 'Export test' },
+  ],
+}
+
+test.describe('Export downloads', () => {
+  test('downloads JSON, CSV and Markdown', async ({ page }) => {
+    await mockFetch(page, mockFindings)
+
+    await page.goto('/')
+    await page.locator('textarea').first().fill('pub fn test() {}')
+    await page.locator('button:has-text("Scan Contract")').click()
+    await page.waitForURL(/\/results/)
+
+    // JSON
+    const [jsonDownload] = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('button:has-text("Download JSON")'),
+    ])
+    const jsonPath = await jsonDownload.path()
+    const jsonContent = await fs.readFile(jsonPath!, 'utf8')
+    expect(jsonContent).toContain('export-check')
+
+    // CSV
+    const [csvDownload] = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('button:has-text("Download CSV")'),
+    ])
+    const csvPath = await csvDownload.path()
+    const csvContent = await fs.readFile(csvPath!, 'utf8')
+    expect(csvContent).toContain('check_name')
+    expect(csvContent).toContain('export-check')
+
+    // Markdown
+    const [mdDownload] = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('button:has-text("Download Markdown")'),
+    ])
+    const mdPath = await mdDownload.path()
+    const mdContent = await fs.readFile(mdPath!, 'utf8')
+    expect(mdContent).toContain('# Soroban Guard Security Report')
+    expect(mdContent).toContain('export-check')
+  })
+})


### PR DESCRIPTION
Closes #235

---

Adds Playwright tests that trigger each export and verify the downloaded file content. Also adds Download JSON/CSV/Markdown buttons to the results page.