### PR TITLE
ci: skip Vercel deploy when VERCEL_TOKEN secret is not configured

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check Vercel configuration
+        id: check
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -n "$VERCEL_TOKEN" ]; then
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=false" >> $GITHUB_OUTPUT
+            echo "VERCEL_TOKEN secret not configured — skipping deployment."
+          fi
+
       - uses: amondnet/vercel-action@v25
+        if: steps.check.outputs.enabled == 'true'
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.ORG_ID }}


### PR DESCRIPTION


The amondnet/vercel-action throws a hard error if vercel-token is absent. Add a preflight step that checks the secret via an env var and gates the deploy step behind its output, so PRs pass CI even when Vercel secrets are not set up in the repository.


