### PR TITLE
feat(architecture): add feature-flag system for in-progress features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,15 @@ echo "NEXT_PUBLIC_API_URL=http://localhost:3001" > .env.local
 
 `NEXT_PUBLIC_API_URL` should point to a running `soroban-guard-core` instance.
 
+## Feature Flags
+
+Some in-progress features are hidden behind feature flags and default to being turned off. To enable them locally, add the corresponding environment variables to your `.env.local` file:
+
+```bash
+NEXT_PUBLIC_FEATURE_ATTESTATION=true
+NEXT_PUBLIC_FEATURE_I18N=true
+```
+
 ## Running the app
 
 Start the local development server:

--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -34,6 +34,7 @@ import SlackNotifyModal from '@/components/SlackNotifyModal'
 import ResultsQRCode from '@/components/ResultsQRCode'
 import { fetchContractTransactions, isValidContractId, type ContractTransaction } from '@/lib/stellar'
 import { NETWORKS } from '@/types/stellar'
+import { isFeatureEnabled } from '@/lib/featureFlags'
 
 export default function ResultsClient() {
   const router = useRouter()
@@ -334,7 +335,7 @@ export default function ResultsClient() {
             )}
             {/* Secondary actions — visible on desktop, collapsed on mobile */}
             <div className="hidden items-center gap-2 sm:flex">
-              {findings.length === 0 && walletKey && (
+              {findings.length === 0 && walletKey && isFeatureEnabled('attestation') && (
                 <button
                   onClick={handleAttest}
                   className="flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-sm text-emerald-300 transition hover:bg-emerald-500/20"
@@ -510,7 +511,7 @@ export default function ResultsClient() {
                       Export to Jira
                     </button>
                   )}
-                  {findings.length === 0 && walletKey && (
+                  {findings.length === 0 && walletKey && isFeatureEnabled('attestation') && (
                     <button
                       onClick={() => { handleAttest(); setShowActionsMenu(false) }}
                       className="w-full px-4 py-2.5 text-left text-sm text-emerald-400 hover:bg-[var(--bg-hover)]"

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -1,0 +1,10 @@
+export type FeatureFlag = 'attestation' | 'i18n';
+
+const flags: Record<FeatureFlag, boolean> = {
+  attestation: process.env.NEXT_PUBLIC_FEATURE_ATTESTATION === 'true',
+  i18n: process.env.NEXT_PUBLIC_FEATURE_I18N === 'true',
+};
+
+export function isFeatureEnabled(feature: FeatureFlag): boolean {
+  return flags[feature] ?? false;
+}


### PR DESCRIPTION
## Description
This PR introduces a lightweight, build-time env-var-driven feature flag system to support dark-launching in-progress features, addressing issue #495. This allows maintainers to safely hide incomplete functionality in production while giving contributors a straightforward way to enable and test these features locally.

### Changes Made:
- **Feature Flag API:** Added `lib/featureFlags.ts` with a strongly-typed `isFeatureEnabled` function driven by `NEXT_PUBLIC_FEATURE_*` environment variables.
- **Attestation Gating:** Wrapped the attestation functionality in `app/results/ResultsClient.tsx` behind the `attestation` feature flag. This defaults to off in a fresh checkout.
- **Documentation:** Added a new "Feature Flags" section to `CONTRIBUTING.md` outlining how to use `.env.local` to toggle features during development.

### How to Test:
1. Start the app normally without any changes to environment variables.
2. Verify that the "Attest on Stellar" / "View attestation" UI elements do not appear when running a scan with a connected wallet.
3. Add `NEXT_PUBLIC_FEATURE_ATTESTATION=true` to your `.env.local` file and restart the development server.
4. Run the app again and verify that the attestation options are now visible and functional.

closes #495 
