### PR TITLE
fix(correctness): stabilize mutedFindings dedupe key against line shifts

### DIFF
--- a/lib/mutedFindings.test.ts
+++ b/lib/mutedFindings.test.ts
@@ -42,5 +42,11 @@ it('muting one finding does not affect another', () => {
 it('persists muted key in localStorage', () => {
   mute(f)
   const stored = JSON.parse(localStorage.getItem('sg_muted_findings')!)
-  expect(stored).toContain('unchecked-auth:src/lib.rs:42')
+  expect(stored).toContain('unchecked-auth:src/lib.rs:transfer')
+})
+
+it('mute survives line-number shift (same function, different line)', () => {
+  mute(f)
+  const shifted = { ...f, line: 99 }
+  expect(isMuted(shifted)).toBe(true)
 })

--- a/lib/mutedFindings.ts
+++ b/lib/mutedFindings.ts
@@ -3,10 +3,12 @@ import type { Finding } from '@/types/findings'
 const STORAGE_KEY = 'sg_muted_findings'
 
 /**
- * Generates a unique key for a finding based on check_name, file_path, and line.
+ * Generates a stable identity key for a finding based on check_name, file_path,
+ * and function_name — omitting line so that muted findings survive line-number
+ * shifts caused by unrelated upstream edits.
  */
 function getFindingKey(finding: Finding): string {
-  return `${finding.check_name}:${finding.file_path}:${finding.line}`
+  return `${finding.check_name}:${finding.file_path}:${finding.function_name}`
 }
 
 /**


### PR DESCRIPTION
## Problem

The dedupe key in `lib/mutedFindings.ts` was `check_name:file_path:line`. Because `line` was a hard-equality field, muting a finding and then re-scanning a contract where unrelated code drifted the line number by even one position caused the mute to silently break — the finding reappeared as "new".

This is the same class of identity fragility that `diffFindings.ts` already solves (via its function-name matching pass), but `mutedFindings.ts` had an independent, unaddressed instance of it.

## Solution

Changed `getFindingKey` from:

${finding.check_name}:${finding.file_path}:${finding.line}

to:

${finding.check_name}:${finding.file_path}:${finding.function_name}

`function_name` is a required field on `Finding` and is stable across unrelated edits that shift lines — it's exactly the same signal `diffFindings.ts` uses in its second matching pass.

## Changes

| File | Change |
|---|---|
| `lib/mutedFindings.ts` | Omit `line` from the identity key; use `function_name` instead |
| `lib/mutedFindings.test.ts` | Update the persisted-key assertion to expect the new format + add a dedicated line-shift resilience test |

## Verification

New test `mute survives line-number shift (same function, different line)`:

1. Mutes a finding at line 42
2. Checks `isMuted` on a copy at line 99 (same `check_name`, `file_path`, `function_name`)
3. Asserts the mute is still active → **passes**

## Notes

- Existing mutes stored with the old key format (`check_name:file_path:line`) will not match after this change. This is acceptable for a correctness fix — stale keys are inert and will be naturally cleaned up as users unmute/remute.
- `function_name` is guaranteed to be present (`string`, not optional) per `types/findings.ts`.

Closes #482