### PR TITLE
feat(reliability): add schema-version field to stored ContractScanRecord

### DIFF
--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { computeAnalytics, checkTrend, allCheckNames } from '../analytics'
 import type { ContractScanRecord } from '@/types/stellar'
+import { CONTRACT_SCAN_RECORD_SCHEMA_VERSION } from '@/types/stellar'
 
 function makeRecord(
   overrides: Partial<ContractScanRecord> & { findings?: ContractScanRecord['findings'] },
 ): ContractScanRecord {
   return {
+    schemaVersion: CONTRACT_SCAN_RECORD_SCHEMA_VERSION,
     id: 'id-1',
     publicKey: 'GPUB',
     contractId: 'C1',

--- a/lib/__tests__/history.test.ts
+++ b/lib/__tests__/history.test.ts
@@ -1,4 +1,5 @@
-import { addScanRecord, getScanHistory, getById, clearScanHistory } from '../history'
+import { addScanRecord, getScanHistory, getById, clearScanHistory, getAllScanHistory } from '../history'
+import { CONTRACT_SCAN_RECORD_SCHEMA_VERSION } from '@/types/stellar'
 
 const STORAGE_KEY = 'sg_scan_history'
 
@@ -9,6 +10,7 @@ const mockLocalStorage = (() => {
     setItem: jest.fn((key: string, value: string) => { store[key] = value }),
     removeItem: jest.fn((key: string) => { delete store[key] }),
     clear: () => { store = {} },
+    _store: () => store,
   }
 })()
 
@@ -68,6 +70,12 @@ describe('addScanRecord', () => {
     const lastCall = mockLocalStorage.setItem.mock.calls.at(-1)![1]
     expect(JSON.parse(lastCall)).toHaveLength(50)
   })
+
+  it('writes new records with schemaVersion', () => {
+    addScanRecord('PK', 'CTR', 'testnet', [])
+    const stored = JSON.parse(mockLocalStorage.setItem.mock.calls[0][1])
+    expect(stored[0].schemaVersion).toBe(CONTRACT_SCAN_RECORD_SCHEMA_VERSION)
+  })
 })
 
 describe('getScanHistory', () => {
@@ -118,5 +126,84 @@ describe('clearScanHistory', () => {
     addScanRecord('PK', 'CTR1', 'testnet', [])
     clearScanHistory()
     expect(getScanHistory('PK')).toEqual([])
+  })
+})
+
+describe('schema migration', () => {
+  function injectLegacyRecords(records: unknown[]) {
+    mockLocalStorage._store()[STORAGE_KEY] = JSON.stringify(records)
+  }
+
+  it('migrates version-0 (unversioned) records on read', () => {
+    const legacy = {
+      id: '1',
+      publicKey: 'PK',
+      contractId: 'CTR',
+      network: 'testnet',
+      scannedAt: '2024-01-01T00:00:00.000Z',
+      findingCount: 0,
+      highCount: 0,
+      mediumCount: 0,
+      lowCount: 0,
+      findings: [],
+    }
+    injectLegacyRecords([legacy])
+
+    const result = getAllScanHistory()
+    expect(result).toHaveLength(1)
+    expect(result[0].schemaVersion).toBe(CONTRACT_SCAN_RECORD_SCHEMA_VERSION)
+    expect(result[0].contractId).toBe('CTR')
+  })
+
+  it('preserves existing schemaVersion on already-migrated records', () => {
+    const migrated = {
+      schemaVersion: CONTRACT_SCAN_RECORD_SCHEMA_VERSION,
+      id: '1',
+      publicKey: 'PK',
+      contractId: 'CTR',
+      network: 'testnet',
+      scannedAt: '2024-01-01T00:00:00.000Z',
+      findingCount: 0,
+      highCount: 0,
+      mediumCount: 0,
+      lowCount: 0,
+      findings: [],
+    }
+    injectLegacyRecords([migrated])
+
+    const result = getAllScanHistory()
+    expect(result[0].schemaVersion).toBe(CONTRACT_SCAN_RECORD_SCHEMA_VERSION)
+  })
+
+  it('silently drops non-object entries', () => {
+    injectLegacyRecords([null, 42, 'string', { id: '1', publicKey: 'PK', contractId: 'CTR', network: 'testnet', scannedAt: '', findingCount: 0, highCount: 0, mediumCount: 0, lowCount: 0, findings: [] }])
+
+    const result = getAllScanHistory()
+    expect(result).toHaveLength(1)
+  })
+
+  it('returns empty array for corrupted JSON', () => {
+    mockLocalStorage._store()[STORAGE_KEY] = 'not-json'
+    expect(getAllScanHistory()).toEqual([])
+  })
+
+  it('migrates records accessed via getById', () => {
+    const legacy = {
+      id: '42',
+      publicKey: 'PK',
+      contractId: 'CTR',
+      network: 'testnet',
+      scannedAt: '2024-01-01T00:00:00.000Z',
+      findingCount: 0,
+      highCount: 0,
+      mediumCount: 0,
+      lowCount: 0,
+      findings: [],
+    }
+    injectLegacyRecords([legacy])
+
+    const result = getById('42')
+    expect(result).not.toBeNull()
+    expect(result!.schemaVersion).toBe(CONTRACT_SCAN_RECORD_SCHEMA_VERSION)
   })
 })

--- a/lib/history.ts
+++ b/lib/history.ts
@@ -1,6 +1,39 @@
 import type { ContractScanRecord } from '@/types/stellar'
+import { CONTRACT_SCAN_RECORD_SCHEMA_VERSION } from '@/types/stellar'
 
 const STORAGE_KEY = 'sg_scan_history'
+
+type StoredRecord = Record<string, unknown> & { id?: string }
+
+/**
+ * Migrate a legacy (unversioned / schemaVersion 0) record to the current schema.
+ * Version 0 records lack the `schemaVersion` field entirely; every other field
+ * has been present since the initial release, so the migration only needs to
+ * stamp the version number.
+ */
+function migrateRecord(record: StoredRecord): ContractScanRecord {
+  const schemaVersion = typeof record.schemaVersion === 'number' ? record.schemaVersion : 0
+  if (schemaVersion >= CONTRACT_SCAN_RECORD_SCHEMA_VERSION) {
+    return record as unknown as ContractScanRecord
+  }
+
+  // Version 0 → 1: add schemaVersion field (all other fields are unchanged)
+  return {
+    ...record,
+    schemaVersion: CONTRACT_SCAN_RECORD_SCHEMA_VERSION,
+  } as unknown as ContractScanRecord
+}
+
+/**
+ * Migrate an array of raw stored records to the current schema.
+ * Silently drops entries that cannot be recovered.
+ */
+function migrateRecords(raw: unknown[]): ContractScanRecord[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .filter((entry): entry is StoredRecord => typeof entry === 'object' && entry !== null)
+    .map(migrateRecord)
+}
 
 /**
  * Retrieve all scan history records from localStorage.
@@ -11,7 +44,8 @@ export function getAllScanHistory(): ContractScanRecord[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return []
-    return JSON.parse(raw) as ContractScanRecord[]
+    const parsed: unknown = JSON.parse(raw)
+    return migrateRecords(parsed as unknown[])
   } catch {
     return []
   }
@@ -39,7 +73,7 @@ export function getScanHistory(publicKey: string): ContractScanRecord[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return []
-    const records = JSON.parse(raw) as ContractScanRecord[]
+    const records = migrateRecords(JSON.parse(raw) as unknown[])
     return records.filter(r => r.publicKey === publicKey)
   } catch {
     return []
@@ -56,7 +90,7 @@ export function getById(id: string): ContractScanRecord | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return null
-    const records = JSON.parse(raw) as ContractScanRecord[]
+    const records = migrateRecords(JSON.parse(raw) as unknown[])
     return records.find(r => r.id === id) || null
   } catch {
     return null
@@ -65,6 +99,8 @@ export function getById(id: string): ContractScanRecord | null {
 
 /**
  * Persist a new scan record to localStorage (capped at 50 entries).
+ * All new records are written with the current schema version.
+ *
  * @param publicKey - Wallet public key that initiated the scan
  * @param contractId - Scanned contract ID
  * @param network - Network name (e.g. 'testnet')
@@ -81,7 +117,7 @@ export function addScanRecord(
   if (typeof window === 'undefined') return
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    const records = raw ? (JSON.parse(raw) as ContractScanRecord[]) : []
+    const records = raw ? migrateRecords(JSON.parse(raw) as unknown[]) : []
 
     const counts = { high: 0, medium: 0, low: 0 }
     for (const f of findings) {
@@ -91,6 +127,7 @@ export function addScanRecord(
     }
 
     const record: ContractScanRecord = {
+      schemaVersion: CONTRACT_SCAN_RECORD_SCHEMA_VERSION,
       id: Date.now().toString(),
       publicKey,
       contractId,

--- a/types/stellar.ts
+++ b/types/stellar.ts
@@ -34,7 +34,10 @@ export interface WalletState {
   network: StellarNetwork
 }
 
+export const CONTRACT_SCAN_RECORD_SCHEMA_VERSION = 1
+
 export interface ContractScanRecord {
+  schemaVersion: number
   publicKey: string
   contractId: string
   network: string


### PR DESCRIPTION
## Problem

ContractScanRecord is stored directly in localStorage with no version field. Any future change to this shape will silently break for users with existing history records already in their browser, with no way to distinguish "old shape" from "corrupted data".

## Changes

- Add `schemaVersion` field to `ContractScanRecord` in `types/stellar.ts`
- Add `CONTRACT_SCAN_RECORD_SCHEMA_VERSION` constant for the current schema version (1)
- Add `migrateRecord()` / `migrateRecords()` in `lib/history.ts`:
  - Version 0 (unversioned) records are auto-upgraded by stamping the current schema version
  - Non-object entries are silently dropped
  - All read functions (`getAllScanHistory`, `getScanHistory`, `getById`) run migration transparently
- `addScanRecord()` writes new records with the current schema version
- Updated existing tests and added migration-specific tests

## Acceptance Criteria

- [x] New records are written with an explicit schema version
- [x] Existing unversioned records already in localStorage are read correctly via a migration path, not silently dropped

## Verification

- ✅ `tsc --noEmit` passes
- ✅ 19 jest history tests pass (including 5 new migration tests)
- ✅ 12 vitest analytics tests pass

Closes #481