### PR TITLE
feat: add animated splash screen on first visit

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,113 @@ html[data-theme='light'] ::-webkit-scrollbar-thumb:hover {
   background: #cbd5e1;
 }
 
+/* Splash screen */
+.splash-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  animation: splashFadeOut 0.4s ease-in 1.4s forwards;
+}
+
+.splash-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.splash-logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  animation: splashZoomIn 0.6s ease-out forwards;
+  opacity: 0;
+}
+
+.splash-logo-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 5rem;
+  height: 5rem;
+  border-radius: 1rem;
+  background: #6366f1;
+}
+
+.splash-shield {
+  width: 2.5rem;
+  height: 2.5rem;
+  color: white;
+}
+
+.splash-wordmark {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.splash-progress {
+  width: 12rem;
+  height: 3px;
+  border-radius: 9999px;
+  background: var(--border);
+  overflow: hidden;
+  opacity: 0;
+  animation: splashFadeIn 0.3s ease-out 0.4s forwards;
+}
+
+.splash-progress-bar {
+  height: 100%;
+  border-radius: 9999px;
+  background: #6366f1;
+  animation: splashProgress 1.2s ease-in-out 0.4s forwards;
+}
+
+.splash-content-hidden {
+  opacity: 0;
+}
+
+.splash-content-visible {
+  opacity: 1;
+  animation: splashContentFadeIn 0.3s ease-out forwards;
+}
+
+@keyframes splashZoomIn {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes splashFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes splashProgress {
+  from { width: 0; }
+  to { width: 100%; }
+}
+
+@keyframes splashFadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; pointer-events: none; }
+}
+
+@keyframes splashContentFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 /* Screen reader only */
 .sr-only {
   position: absolute;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { WalletProvider } from '@/lib/WalletContext'
 import { ToastProvider } from '@/lib/toast'
 import ToastContainer from '@/components/ToastContainer'
 import ErrorBoundary from '@/components/ErrorBoundary'
+import SplashScreen from '@/components/SplashScreen'
 import { validateEnv } from '@/lib/env'
 
 validateEnv()
@@ -47,16 +48,18 @@ export default function RootLayout({
         >
           Skip to main content
         </a>
-        <ErrorBoundary>
-          <WalletProvider>
-            <ToastProvider>
-              <main id="main-content" tabIndex={-1}>
-                {children}
-              </main>
-              <ToastContainer />
-            </ToastProvider>
-          </WalletProvider>
-        </ErrorBoundary>
+        <SplashScreen>
+          <ErrorBoundary>
+            <WalletProvider>
+              <ToastProvider>
+                <main id="main-content" tabIndex={-1}>
+                  {children}
+                </main>
+                <ToastContainer />
+              </ToastProvider>
+            </WalletProvider>
+          </ErrorBoundary>
+        </SplashScreen>
       </body>
     </html>
   )

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+const SESSION_STORAGE_KEY = 'sg_splash_seen'
+
+export default function SplashScreen({ children }: { children: React.ReactNode }) {
+  const [visible, setVisible] = useState(false)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    const alreadySeen = sessionStorage.getItem(SESSION_STORAGE_KEY)
+    if (alreadySeen) return
+
+    setVisible(true)
+    setMounted(true)
+
+    const timer = setTimeout(() => {
+      setVisible(false)
+      sessionStorage.setItem(SESSION_STORAGE_KEY, '1')
+    }, 1800)
+
+    return () => clearTimeout(timer)
+  }, [])
+
+  if (!mounted) return <>{children}</>
+
+  return (
+    <>
+      {visible && (
+        <div
+          role="status"
+          aria-label="Loading Soroban Guard"
+          className="splash-overlay"
+        >
+          <div className="splash-content">
+            <div className="splash-logo">
+              <div className="splash-logo-icon">
+                <svg
+                  className="splash-shield"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+                  />
+                </svg>
+              </div>
+              <span className="splash-wordmark">Soroban Guard</span>
+            </div>
+            <div className="splash-progress">
+              <div className="splash-progress-bar" />
+            </div>
+          </div>
+        </div>
+      )}
+      <div
+        className={visible ? 'splash-content-hidden' : 'splash-content-visible'}
+      >
+        {children}
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

Add a polished animated splash screen that displays on the user's first visit (or first load of the session). This gives Soroban Guard a more professional feel and provides a smooth entry into the app while any initial data loads.

## Changes

- **components/SplashScreen.tsx** (new): Full-screen splash overlay component with logo, wordmark, and progress bar
- **app/globals.css**: Added CSS keyframe animations for splash screen (zoom-in, fade, progress bar)
- **app/layout.tsx**: Wrapped children with SplashScreen component, gated by sessionStorage

## Features

- Full-screen overlay with Soroban Guard logo/wordmark and animated progress bar
- Fade-in + scale animation for logo entrance
- Progress bar animation while app hydrates (1.8s duration)
- Smooth fade-out before main content is revealed
- Only shows on first session load (sessionStorage flag sg_splash_seen)
- No layout shift after splash exits (content fades in smoothly)
- Works with both light and dark themes (reads CSS custom properties)
- Accessible: role="status" and aria-label="Loading Soroban Guard"

## Acceptance Criteria

- [x] A full-screen splash component renders over the page for ~1.5-2 seconds
- [x] It displays the Soroban Guard logo/wordmark with a fade-in + scale animation
- [x] A subtle progress bar plays while the app is hydrating
- [x] The splash fades out smoothly before the main HomePage is revealed
- [x] It only shows on first session load - sessionStorage flag prevents it on every route change
- [x] No layout shift occurs after the splash exits
- [x] Works correctly with both light and dark themes (reads data-theme attribute)
- [x] Accessible: has role="status" and aria-label="Loading Soroban Guard"

Closes #385
Closes #385
Closes #385
Closes #385
