### PR TITLE
fix(a11y): WCAG AA contrast audit for dark theme + axe-core regressio…

### DIFF
--- a/app/analytics/AnalyticsClient.tsx
+++ b/app/analytics/AnalyticsClient.tsx
@@ -52,21 +52,21 @@ export default function AnalyticsClient() {
 
       <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-10 sm:px-6">
         <h1 className="mb-2 text-2xl font-bold text-white">Portfolio Analytics</h1>
-        <p className="mb-8 text-sm text-slate-500">Aggregate statistics across all scans in your history.</p>
+        <p className="mb-8 text-sm text-slate-400">Aggregate statistics across all scans in your history.</p>
 
         {isEmpty ? (
           <div className="flex flex-col items-center justify-center rounded-xl border border-[var(--border)] bg-[#12151f] py-20 text-center">
-            <svg className="mb-4 h-10 w-10 text-slate-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <svg className="mb-4 h-10 w-10 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
             </svg>
             <p className="text-sm font-medium text-slate-400">Not enough data yet</p>
-            <p className="mt-1 text-xs text-slate-600">
+            <p className="mt-1 text-xs text-slate-400">
               Run at least {MIN_RECORDS} scans to see analytics.{' '}
               {records.length > 0 && `(${records.length} of ${MIN_RECORDS} so far)`}
             </p>
             <Link
               href="/"
-              className="mt-6 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500"
+              className="mt-6 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-[#6264f0]"
             >
               Scan a contract
             </Link>
@@ -90,7 +90,7 @@ export default function AnalyticsClient() {
             <div className="rounded-xl border border-[var(--border)] bg-[#12151f] p-6">
               <h2 className="mb-5 text-sm font-semibold text-slate-300">Top 5 most frequent checks</h2>
               {analytics.topChecks.length === 0 ? (
-                <p className="text-sm text-slate-500">No findings recorded yet.</p>
+                <p className="text-sm text-slate-400">No findings recorded yet.</p>
               ) : (
                 <div className="overflow-x-auto">
                   <div className="min-w-[280px]">
@@ -120,7 +120,7 @@ export default function AnalyticsClient() {
                     </select>
                   </div>
                   {trendData.length < 2 ? (
-                    <p className="text-sm text-slate-500">Not enough data points to show a trend for this check.</p>
+                    <p className="text-sm text-slate-400">Not enough data points to show a trend for this check.</p>
                   ) : (
                     <div className="overflow-x-auto">
                       <div className="min-w-[280px]">
@@ -135,7 +135,7 @@ export default function AnalyticsClient() {
         )}
       </main>
 
-      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
+      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-400">
         Soroban Guard · Veritas Vaults Network
       </footer>
     </div>
@@ -145,7 +145,7 @@ export default function AnalyticsClient() {
 function StatCard({ label, value, color }: { label: string; value: number; color: string }) {
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[#12151f] px-5 py-4">
-      <p className="mb-1 text-xs text-slate-500">{label}</p>
+      <p className="mb-1 text-xs text-slate-400">{label}</p>
       <p className={`text-3xl font-bold ${color}`}>{value}</p>
     </div>
   )
@@ -159,7 +159,7 @@ function TopChecksChart({ checks }: { checks: { name: string; count: number }[] 
         <li key={name}>
           <div className="mb-1 flex items-center justify-between text-xs">
             <span className="font-mono text-slate-300">{name}</span>
-            <span className="text-slate-500">{count}</span>
+            <span className="text-slate-400">{count}</span>
           </div>
           <div className="h-2 w-full overflow-hidden rounded-full bg-[#1a1d27]">
             <div

--- a/app/badge/page.tsx
+++ b/app/badge/page.tsx
@@ -36,7 +36,7 @@ export default function BadgePage() {
       <div className="space-y-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] p-6">
         <div>
           <label htmlFor="contractId" className="mb-1.5 block text-xs font-medium text-slate-400">
-            Contract ID <span className="text-slate-600">(optional)</span>
+            Contract ID <span className="text-slate-400">(optional)</span>
           </label>
           <input
             id="contractId"
@@ -44,7 +44,7 @@ export default function BadgePage() {
             value={contractId}
             onChange={e => setContractId(e.target.value.trim().toUpperCase())}
             placeholder="CABC…XYZ"
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2 font-mono text-sm text-slate-300 placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2 font-mono text-sm text-slate-300 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
             spellCheck={false}
           />
         </div>

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -105,7 +105,7 @@ export default function CompareClient() {
             <h2 className="mb-4 text-lg font-semibold text-red-400">New ({newFindings.length})</h2>
             <div className="space-y-4">
               {newFindings.map((f, i) => (
-                <div key={i} className="ring-2 ring-red-500/50">
+                <div key={i} className="ring-2 ring-red-500/80">
                   <FindingCard finding={f} />
                 </div>
               ))}

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -62,16 +62,16 @@ export default function ComparePage({}: Props) {
           </div>
         </header>
         <main className="flex flex-1 flex-col items-center justify-center gap-4 px-4 text-center">
-          <svg className="h-12 w-12 text-slate-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <svg className="h-12 w-12 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7" />
           </svg>
           <p className="text-base font-medium text-slate-300">No scans selected for comparison</p>
-          <p className="max-w-xs text-sm text-slate-500">
+          <p className="max-w-xs text-sm text-slate-400">
             Go to your scan history, select two scans, and use the Compare button to see a side-by-side diff.
           </p>
           <a
             href="/history"
-            className="mt-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500"
+            className="mt-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-[#6264f0]"
           >
             Browse scan history
           </a>
@@ -144,7 +144,7 @@ export default function ComparePage({}: Props) {
             <h2 className="mb-4 text-lg font-semibold text-red-400">New ({newFindings.length})</h2>
             <div className="space-y-4">
               {newFindings.map((f, i) => (
-                <div key={i} className="ring-2 ring-red-500/50">
+                <div key={i} className="ring-2 ring-red-500/80">
                   <FindingCard finding={f} />
                 </div>
               ))}

--- a/app/docs/api/page.tsx
+++ b/app/docs/api/page.tsx
@@ -11,7 +11,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'
 export default function ApiDocsPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
-      <Link href="/" className="mb-8 inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-300">
+      <Link href="/" className="mb-8 inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-slate-300">
         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
         </svg>
@@ -41,13 +41,13 @@ export default function ApiDocsPage() {
         </p>
 
         <SubHeading>Request</SubHeading>
-        <p className="mb-2 text-sm text-slate-500">Content-Type: application/json</p>
+        <p className="mb-2 text-sm text-slate-400">Content-Type: application/json</p>
         <Code>{`{
   "source": string  // Rust source | GitHub URL | C-address
 }`}</Code>
 
         <SubHeading>Response</SubHeading>
-        <p className="mb-2 text-sm text-slate-500">200 OK — Content-Type: application/json</p>
+        <p className="mb-2 text-sm text-slate-400">200 OK — Content-Type: application/json</p>
         <Code>{`{
   "findings": Finding[]
 }`}</Code>
@@ -88,7 +88,7 @@ export default function ApiDocsPage() {
       <Section title="Error responses">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-[var(--border)] text-left text-slate-500">
+            <tr className="border-b border-[var(--border)] text-left text-slate-400">
               <th className="pb-2 pr-6 font-medium">Status</th>
               <th className="pb-2 font-medium">Meaning</th>
             </tr>
@@ -128,7 +128,7 @@ export default function ApiDocsPage() {
         </p>
 
         <SubHeading>POST /api/webhook</SubHeading>
-        <p className="mb-2 text-sm text-slate-500">Content-Type: application/json</p>
+        <p className="mb-2 text-sm text-slate-400">Content-Type: application/json</p>
         <Code>{`{
   "findings": Finding[]   // same shape as POST /scan response
 }`}</Code>
@@ -170,7 +170,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 }
 
 function SubHeading({ children }: { children: React.ReactNode }) {
-  return <h3 className="mb-2 mt-6 text-sm font-semibold uppercase tracking-wider text-slate-500">{children}</h3>
+  return <h3 className="mb-2 mt-6 text-sm font-semibold uppercase tracking-wider text-slate-400">{children}</h3>
 }
 
 function Code({ children }: { children: React.ReactNode }) {

--- a/app/embed/[token]/page.tsx
+++ b/app/embed/[token]/page.tsx
@@ -60,7 +60,7 @@ export default function EmbedPage({ params }: Props) {
           {/* Counts */}
           <div style={{ display: 'flex', gap: 6 }}>
             {(['High', 'Medium', 'Low'] as const).map(sev => {
-              const colors: Record<string, string> = { High: '#ef4444', Medium: '#f59e0b', Low: '#38bdf8' }
+              const colors: Record<string, string> = { High: '#f87171', Medium: '#f59e0b', Low: '#38bdf8' }
               return (
                 <div key={sev} style={{
                   flex: 1,
@@ -70,7 +70,7 @@ export default function EmbedPage({ params }: Props) {
                   textAlign: 'center',
                 }}>
                   <div style={{ color: colors[sev], fontSize: 14, fontWeight: 700 }}>{counts[sev]}</div>
-                  <div style={{ color: '#64748b', fontSize: 9, marginTop: 1 }}>{sev}</div>
+                  <div style={{ color: '#94a3b8', fontSize: 9, marginTop: 1 }}>{sev}</div>
                 </div>
               )
             })}
@@ -78,12 +78,12 @@ export default function EmbedPage({ params }: Props) {
 
           {/* Footer */}
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <span style={{ color: '#475569', fontSize: 9 }}>Scanned {scanDate}</span>
+            <span style={{ color: '#94a3b8', fontSize: 9 }}>Scanned {scanDate}</span>
             <a
               href="https://github.com/Veritas-Vaults-Network/soroban-guard-web"
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: '#6366f1', fontSize: 9, textDecoration: 'none' }}
+              style={{ color: '#818cf8', fontSize: 9, textDecoration: 'none' }}
             >
               Powered by Soroban Guard
             </a>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,6 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap');
+@import 'tailwindcss';
+@config '../tailwind.config.ts';
 
 :root {
   --bg: #0f1117;
@@ -13,6 +11,11 @@
   --text: #e2e8f0;
   --text-secondary: #a1aec7;
   --text-tertiary: #64748b;
+  --warning-text: #fde68a;
+  --warning-text-secondary: #fcd34d;
+  --warning-icon: #fbbf24;
+  --warning-dismiss: #fbbf24;
+  --warning-dismiss-hover: #fcd34d;
 }
 
 html[data-theme='light'] {
@@ -24,6 +27,11 @@ html[data-theme='light'] {
   --text: #1e293b;
   --text-secondary: #475569;
   --text-tertiary: #94a3b8;
+  --warning-text: #78350f;
+  --warning-text-secondary: #92400e;
+  --warning-icon: #b45309;
+  --warning-dismiss: #b45309;
+  --warning-dismiss-hover: #92400e;
 }
 
 html {

--- a/app/history/HistoryClient.tsx
+++ b/app/history/HistoryClient.tsx
@@ -86,7 +86,7 @@ export default function HistoryClient() {
       </div>
 
       {entries.length === 0 ? (
-        <p className="text-sm text-slate-500">No scan history yet.</p>
+        <p className="text-sm text-slate-400">No scan history yet.</p>
       ) : (
         <>
           {entries.length >= 7 && (
@@ -114,18 +114,18 @@ export default function HistoryClient() {
               >
                 <div className="flex items-center justify-between">
                   <span className="truncate font-mono text-sm text-slate-300">{e.source}</span>
-                  <span className="ml-4 shrink-0 text-xs text-slate-500">
+                  <span className="ml-4 shrink-0 text-xs text-slate-400">
                     {new Date(e.date).toLocaleDateString()}
                   </span>
                 </div>
-                <p className="mt-1 text-xs text-slate-500">
+                <p className="mt-1 text-xs text-slate-400">
                   {e.findings.length} finding{e.findings.length !== 1 ? 's' : ''}
                 </p>
                 <div className="mt-3 flex items-center gap-2">
-                  <svg className="h-3.5 w-3.5 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <svg className="h-3.5 w-3.5 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
-                  <span className="text-xs text-slate-500">Rescan:</span>
+                  <span className="text-xs text-slate-400">Rescan:</span>
                   {(['never', 'daily', 'weekly'] as const).map(opt => (
                     <button
                       key={opt}
@@ -133,7 +133,7 @@ export default function HistoryClient() {
                       className={`rounded-md px-2 py-0.5 text-xs font-medium transition ${
                         (opt === 'never' && !schedules[e.id]) || schedules[e.id] === opt
                           ? 'bg-indigo-500/20 text-indigo-300'
-                          : 'text-slate-500 hover:text-slate-300'
+                          : 'text-slate-400 hover:text-slate-300'
                       }`}
                     >
                       {opt.charAt(0).toUpperCase() + opt.slice(1)}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -206,16 +206,16 @@ export default function HistoryPage() {
         <div className="mb-4 flex items-center justify-between">
           <div>
             <h2 className="text-lg font-semibold text-white">Wallet activity trail</h2>
-            <p className="mt-1 text-sm text-slate-500">
+            <p className="mt-1 text-sm text-slate-400">
               {publicKey ? 'Your connected wallet actions are stored here for review.' : 'Connect a wallet to view your own audit trail.'}
             </p>
           </div>
         </div>
 
         {auditLoading ? (
-          <div className="text-sm text-slate-500">Loading audit trail…</div>
+          <div className="text-sm text-slate-400">Loading audit trail…</div>
         ) : auditEntries.length === 0 ? (
-          <div className="rounded-xl border border-dashed border-[#2a2d3a] px-4 py-6 text-sm text-slate-500">
+          <div className="rounded-xl border border-dashed border-[#2a2d3a] px-4 py-6 text-sm text-slate-400">
             No audit events recorded yet.
           </div>
         ) : (
@@ -225,9 +225,9 @@ export default function HistoryPage() {
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <p className="text-sm font-medium text-slate-200">{entry.action} → {entry.target}</p>
-                    <p className="text-xs text-slate-500">{entry.actor}</p>
+                    <p className="text-xs text-slate-400">{entry.actor}</p>
                   </div>
-                  <span className="text-xs text-slate-500">{new Date(entry.timestamp).toLocaleString()}</span>
+                  <span className="text-xs text-slate-400">{new Date(entry.timestamp).toLocaleString()}</span>
                 </div>
               </li>
             ))}
@@ -256,13 +256,13 @@ export default function HistoryPage() {
           <h2 className="mb-2 text-lg font-semibold text-slate-200">
             No scan history yet
           </h2>
-          <p className="mb-6 max-w-sm text-sm text-slate-500">
+          <p className="mb-6 max-w-sm text-sm text-slate-400">
             Start by scanning your first smart contract to build your security
             history and track vulnerabilities over time.
           </p>
           <Link
             href="/"
-            className="rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-indigo-500"
+            className="rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-[#6264f0]"
           >
             Run first scan
           </Link>
@@ -316,17 +316,17 @@ export default function HistoryPage() {
                   <span className="truncate font-mono text-sm text-slate-300">
                     {e.source}
                   </span>
-                  <span className="ml-4 shrink-0 text-xs text-slate-500">
+                  <span className="ml-4 shrink-0 text-xs text-slate-400">
                     {new Date(e.date).toLocaleDateString()}
                   </span>
                 </div>
-                <p className="mt-1 text-xs text-slate-500">
+                <p className="mt-1 text-xs text-slate-400">
                   {e.findings.length} finding
                   {e.findings.length !== 1 ? "s" : ""}
                 </p>
                 <div className="mt-3 flex items-center gap-2">
                   <svg
-                    className="h-3.5 w-3.5 text-slate-500"
+                    className="h-3.5 w-3.5 text-slate-400"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -339,7 +339,7 @@ export default function HistoryPage() {
                       d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
                     />
                   </svg>
-                  <span className="text-xs text-slate-500">Rescan:</span>
+                  <span className="text-xs text-slate-400">Rescan:</span>
                   {(["never", "daily", "weekly"] as const).map((opt) => (
                     <button
                       key={opt}
@@ -348,7 +348,7 @@ export default function HistoryPage() {
                         (opt === "never" && !schedules[e.id]) ||
                         schedules[e.id] === opt
                           ? "bg-indigo-500/20 text-indigo-300"
-                          : "text-slate-500 hover:text-slate-300"
+                          : "text-slate-400 hover:text-slate-300"
                       }`}
                     >
                       {opt.charAt(0).toUpperCase() + opt.slice(1)}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -11,7 +11,7 @@ export default function Loading() {
         >
           <path strokeLinecap="round" d="M12 2a10 10 0 0 1 10 10" />
         </svg>
-        <p className="text-sm text-slate-500">Loading…</p>
+        <p className="text-sm text-slate-400">Loading…</p>
       </div>
     </div>
   )

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -7,12 +7,12 @@ export default function NotFound() {
   const { t } = useT()
   return (
     <div className="flex min-h-screen flex-col items-center justify-center text-center">
-      <p className="mb-2 font-mono text-6xl font-bold text-slate-700">{t('notFound.code')}</p>
+      <p className="mb-2 font-mono text-6xl font-bold text-slate-500">{t('notFound.code')}</p>
       <h1 className="mb-4 text-xl font-semibold text-slate-300">{t('notFound.heading')}</h1>
-      <p className="mb-8 text-sm text-slate-500">{t('notFound.body')}</p>
+      <p className="mb-8 text-sm text-slate-400">{t('notFound.body')}</p>
       <Link
         href="/"
-        className="rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-indigo-500"
+        className="rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-[#6264f0]"
       >
         {t('notFound.backToScanner')}
       </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -284,7 +284,7 @@ export default function HomePage() {
                ) : contractsError ? (
                  <p className="text-sm text-red-400">Error loading contracts.</p>
                ) : contracts.length === 0 ? (
-                 <p className="text-sm text-slate-500">No deployed contracts found.</p>
+                 <p className="text-sm text-slate-400">No deployed contracts found.</p>
                ) : (
                  <div className="flex flex-wrap gap-3">
                    {contracts.map((contract, idx) => (
@@ -341,7 +341,7 @@ export default function HomePage() {
                         <p className="truncate font-mono text-sm text-slate-300">
                           {record.contractId.slice(0, 12)}...{record.contractId.slice(-8)}
                         </p>
-                        <p className="text-xs text-slate-500">
+                        <p className="text-xs text-slate-400">
                           {new Date(record.scannedAt).toLocaleDateString()}
                         </p>
                       </div>
@@ -396,7 +396,7 @@ export default function HomePage() {
                      <p className="mb-4 flex-1 text-slate-400 text-center">{contract.description}</p>
                      <div className="w-full">
                        <NetworkBadge network={NETWORKS.testnet} />
-                       <span className="ml-2 font-mono text-xs text-slate-500">
+                       <span className="ml-2 font-mono text-xs text-slate-400">
                          {contract.contractId.slice(0, 8)}...{contract.contractId.slice(-8)}
                        </span>
                      </div>
@@ -476,12 +476,12 @@ export default function HomePage() {
         </section>
       </main>
 
-      <footer className="border-t border-[var(--border)] py-8 text-center text-sm text-slate-600">
+      <footer className="border-t border-[var(--border)] py-8 text-center text-sm text-slate-400">
         <p>
           Built by{' '}
           <a
             href="https://github.com/Veritas-Vaults-Network"
-            className="text-slate-500 hover:text-slate-300"
+            className="text-slate-400 hover:text-slate-300"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -546,7 +546,7 @@ function Step({
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-500/10 text-indigo-400 ring-1 ring-indigo-500/20">
           {icon}
         </div>
-        <span className="font-mono text-xs font-bold text-slate-600">{number}</span>
+        <span className="font-mono text-xs font-bold text-slate-400">{number}</span>
       </div>
       <h3 className="mb-2 font-semibold text-white">{title}</h3>
       <p className="text-sm leading-relaxed text-slate-400">{description}</p>
@@ -587,7 +587,7 @@ function RepoCard({
           </span>
         )}
       </div>
-      <p className="text-xs leading-relaxed text-slate-500">{description}</p>
+      <p className="text-xs leading-relaxed text-slate-400">{description}</p>
     </a>
   )
 }

--- a/app/results/ResultsClient.tsx
+++ b/app/results/ResultsClient.tsx
@@ -611,7 +611,7 @@ export default function ResultsClient() {
             </div>
             <button
               onClick={handleScanAnother}
-              className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-indigo-500 sm:px-4"
+              className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-[#6264f0] sm:px-4"
             >
               <span className="hidden sm:inline">Scan another contract</span>
               <span className="sm:hidden">New scan</span>
@@ -656,13 +656,13 @@ export default function ResultsClient() {
               )}
             </div>
           </div>
-          <p className="mb-6 text-sm text-slate-500">
+          <p className="mb-6 text-sm text-slate-400">
             {multiNetworkResults
               ? `${findings.length} finding${findings.length !== 1 ? 's' : ''} detected across ${multiNetworkResults.length} networks.`
               : findings.length === 0
                 ? 'No issues detected.'
                 : `${findings.length} finding${findings.length !== 1 ? 's' : ''} detected across your contract.`}
-            {duration && <span className="ml-2 text-slate-600">Scanned in {duration}s</span>}
+            {duration && <span className="ml-2 text-slate-400">Scanned in {duration}s</span>}
           </p>
 
           <div className="flex gap-6">
@@ -745,7 +745,7 @@ export default function ResultsClient() {
                       className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition ${
                         isActive
                           ? `${statusColor} ring-1 ring-current`
-                          : 'border-[var(--border)] text-slate-500 hover:text-slate-300'
+                          : 'border-[var(--border)] text-slate-400 hover:text-slate-300'
                       }`}
                     >
                       {network && (
@@ -850,7 +850,7 @@ export default function ResultsClient() {
                   Vulnerability themes
                 </span>
                 <svg
-                  className={`h-4 w-4 text-slate-500 transition-transform duration-200 ${showWordCloud ? 'rotate-180' : ''}`}
+                  className={`h-4 w-4 text-slate-400 transition-transform duration-200 ${showWordCloud ? 'rotate-180' : ''}`}
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -920,7 +920,7 @@ export default function ResultsClient() {
                   <label htmlFor="findings-search" className="sr-only">
                     Search findings
                   </label>
-                  <svg className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <svg className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
                   </svg>
                   <input
@@ -929,13 +929,13 @@ export default function ResultsClient() {
                     value={searchQuery}
                     onChange={e => setSearchQuery(e.target.value)}
                     placeholder="Search by check, function, file, or description..."
-                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] py-2 pl-9 pr-9 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] py-2 pl-9 pr-9 text-sm text-slate-200 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                   />
                   {searchQuery && (
                     <button
                       onClick={() => setSearchQuery('')}
                       aria-label="Clear search"
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-white"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white"
                     >
                       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                         <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -950,7 +950,7 @@ export default function ResultsClient() {
                   muteTrigger={muteTrigger}
                 />
                 {filteredFindings.length === 0 ? (
-                  <p className="py-10 text-center text-sm text-slate-500">No findings match your search.</p>
+                  <p className="py-10 text-center text-sm text-slate-400">No findings match your search.</p>
                 ) : groupView === 'function' ? (
                   <FindingsByFunction findings={filteredFindings} onMuteChange={handleMuteChange} />
                 ) : groupView === 'file' ? (
@@ -978,7 +978,7 @@ export default function ResultsClient() {
             <div className="overflow-hidden rounded-xl border border-[var(--border)]">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)] text-xs text-slate-500">
+                  <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)] text-xs text-slate-400">
                     <th className="px-4 py-2 text-left font-medium">Hash</th>
                     <th className="px-4 py-2 text-left font-medium">Date</th>
                     <th className="px-4 py-2 text-right font-medium">Ops</th>
@@ -1015,7 +1015,7 @@ export default function ResultsClient() {
       <button
         onClick={handleScanAnother}
         aria-label="Scan another contract"
-        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-indigo-500 sm:hidden"
+        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-[#6264f0] sm:hidden"
       >
         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
@@ -1023,7 +1023,7 @@ export default function ResultsClient() {
         New scan
       </button>
 
-      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
+      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-400">
         Soroban Guard · Veritas Vaults Network
       </footer>
 
@@ -1109,7 +1109,7 @@ function SummaryCard({
 }) {
   return (
     <div className={`rounded-xl border ${border || 'border-[var(--border)]'} ${bg} p-4`}>
-      <p className="mb-1 text-xs text-slate-500">{label}</p>
+      <p className="mb-1 text-xs text-slate-400">{label}</p>
       <p className={`text-2xl font-bold ${color}`}>{value}</p>
     </div>
   )

--- a/app/results/[id]/page.tsx
+++ b/app/results/[id]/page.tsx
@@ -80,7 +80,7 @@ export default async function PermalinkPage({ params }: Props) {
       <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6">
         <div className="mb-8">
           <h1 className="mb-2 text-2xl font-bold text-white">Scan Results</h1>
-          <p className="mb-6 text-sm text-slate-500">
+          <p className="mb-6 text-sm text-slate-400">
             {list.length === 0
               ? 'No issues detected.'
               : `${list.length} finding${list.length !== 1 ? 's' : ''} detected.`}
@@ -88,7 +88,7 @@ export default async function PermalinkPage({ params }: Props) {
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
             {(['Critical', 'High', 'Medium', 'Low'] as Severity[]).map(s => (
               <div key={s} className="rounded-xl border border-[var(--border)] bg-[#1a1d27] px-5 py-4">
-                <p className="mb-1 text-xs text-slate-500">{s}</p>
+                <p className="mb-1 text-xs text-slate-400">{s}</p>
                 <p className="text-3xl font-bold text-white">{counts[s]}</p>
               </div>
             ))}
@@ -96,7 +96,7 @@ export default async function PermalinkPage({ params }: Props) {
         </div>
 
         {list.length === 0 ? (
-          <p className="py-10 text-center text-sm text-slate-500">No findings to display.</p>
+          <p className="py-10 text-center text-sm text-slate-400">No findings to display.</p>
         ) : (
           <>
             <div className="mb-3 flex items-center justify-between">
@@ -112,7 +112,7 @@ export default async function PermalinkPage({ params }: Props) {
         )}
       </main>
 
-      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
+      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-400">
         Soroban Guard · Veritas Vaults Network
       </footer>
     </div>

--- a/app/webhook/[token]/WebhookLoader.tsx
+++ b/app/webhook/[token]/WebhookLoader.tsx
@@ -33,7 +33,7 @@ export default function WebhookTokenPage({ findings, revoked }: Props) {
         </p>
         <Link
           href="/"
-          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-indigo-500"
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-[#6264f0]"
         >
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />

--- a/app/workspace/[token]/page.tsx
+++ b/app/workspace/[token]/page.tsx
@@ -92,7 +92,7 @@ export default function WorkspacePage() {
             </p>
             <Link
               href="/"
-              className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-indigo-500"
+              className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-[#6264f0]"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
@@ -156,7 +156,7 @@ export default function WorkspacePage() {
       <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:px-6">
         <div className="mb-8">
           <h1 className="mb-2 text-2xl font-bold text-white">Shared Scan Results</h1>
-          <p className="mb-6 text-sm text-slate-500">
+          <p className="mb-6 text-sm text-slate-400">
             {findings.length === 0
               ? 'No issues detected.'
               : `${findings.length} finding${findings.length !== 1 ? 's' : ''} detected.`}
@@ -179,14 +179,14 @@ export default function WorkspacePage() {
               aria-expanded={sourceOpen}
             >
               <span className="flex items-center gap-2">
-                <svg className="h-4 w-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <svg className="h-4 w-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
                 </svg>
                 Contract source
-                <span className="text-xs text-slate-500 font-normal">(read-only)</span>
+                <span className="text-xs text-slate-400 font-normal">(read-only)</span>
               </span>
               <svg
-                className={`h-4 w-4 text-slate-500 transition-transform ${sourceOpen ? 'rotate-180' : ''}`}
+                className={`h-4 w-4 text-slate-400 transition-transform ${sourceOpen ? 'rotate-180' : ''}`}
                 fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
                 aria-hidden="true"
               >
@@ -199,7 +199,7 @@ export default function WorkspacePage() {
                   <tbody>
                     {source.split('\n').map((line, i) => (
                       <tr key={i}>
-                        <td className="select-none w-10 px-3 py-0.5 text-right font-mono text-slate-600" aria-hidden="true">
+                        <td className="select-none w-10 px-3 py-0.5 text-right font-mono text-slate-400" aria-hidden="true">
                           {i + 1}
                         </td>
                         <td className="px-3 py-0.5 font-mono whitespace-pre text-slate-300">
@@ -231,7 +231,7 @@ export default function WorkspacePage() {
         )}
       </main>
 
-      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-600">
+      <footer className="border-t border-[var(--border)] py-6 text-center text-xs text-slate-400">
         Soroban Guard · Veritas Vaults Network
       </footer>
     </div>
@@ -245,7 +245,7 @@ function SummaryCard({
 }) {
   return (
     <div className={`rounded-xl border ${border} ${bg} px-5 py-4`}>
-      <p className="mb-1 text-xs text-slate-500">{label}</p>
+      <p className="mb-1 text-xs text-slate-400">{label}</p>
       <p className={`text-3xl font-bold ${color}`}>{value}</p>
     </div>
   )

--- a/components/BatchScanButton.tsx
+++ b/components/BatchScanButton.tsx
@@ -141,7 +141,7 @@ export default function BatchScanButton({
           onChange={e => setManualInput(e.target.value)}
           placeholder="Paste contract IDs (one per line or comma-separated) — optional"
           rows={3}
-          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-xs font-mono text-slate-300 placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-xs font-mono text-slate-300 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
         />
         <button
           onClick={handleStart}
@@ -213,7 +213,7 @@ export default function BatchScanButton({
 
       <button
         onClick={() => { setState('idle'); setContracts([]); setCurrent(0); setResults([]) }}
-        className="text-xs text-slate-500 hover:text-slate-300 transition"
+        className="text-xs text-slate-400 hover:text-slate-300 transition"
       >
         Dismiss
       </button>

--- a/components/CheckTrendChart.tsx
+++ b/components/CheckTrendChart.tsx
@@ -47,12 +47,12 @@ export default function CheckTrendChart({ data, checkName }: Props) {
           <LineChart data={data} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
             <XAxis
               dataKey="date"
-              tick={{ fill: '#64748b', fontSize: 11 }}
+              tick={{ fill: '#94a3b8', fontSize: 11 }}
               axisLine={false}
               tickLine={false}
             />
             <YAxis
-              tick={{ fill: '#64748b', fontSize: 11 }}
+              tick={{ fill: '#94a3b8', fontSize: 11 }}
               axisLine={false}
               tickLine={false}
             />

--- a/components/CodeViewer.tsx
+++ b/components/CodeViewer.tsx
@@ -101,7 +101,7 @@ export default function CodeViewer({ source, highlightLine }: Props) {
                 className={isHighlight ? 'bg-amber-500/15' : undefined}
               >
                 <td
-                  className="select-none px-3 py-0.5 text-right font-mono text-slate-600 w-10 shrink-0"
+                  className="select-none px-3 py-0.5 text-right font-mono text-slate-400 w-10 shrink-0"
                   aria-hidden="true"
                 >
                   {lineNum}

--- a/components/DiscordNotifyModal.tsx
+++ b/components/DiscordNotifyModal.tsx
@@ -50,7 +50,7 @@ export default function DiscordNotifyModal({ findings, source, onClose }: Props)
       >
         <div className="mb-5 flex items-center justify-between">
           <h2 id={titleId} className="text-base font-semibold text-white">Send to Discord</h2>
-          <button onClick={onClose} aria-label="Close dialog" className="rounded text-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+          <button onClick={onClose} aria-label="Close dialog" className="rounded text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -60,7 +60,7 @@ export default function DiscordNotifyModal({ findings, source, onClose }: Props)
         {status === 'done' ? (
           <div className="space-y-3">
             <p className="text-sm text-emerald-400">✓ Scan results sent to Discord</p>
-            <button onClick={onClose} className="w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500">
+            <button onClick={onClose} className="w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-[#6264f0]">
               Done
             </button>
           </div>
@@ -72,14 +72,14 @@ export default function DiscordNotifyModal({ findings, source, onClose }: Props)
               onChange={e => setWebhookUrl(e.target.value)}
               placeholder="Discord Webhook URL"
               disabled={status === 'sending'}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
-            <p className="text-xs text-slate-500">Webhook URL is never stored or sent to our servers.</p>
+            <p className="text-xs text-slate-400">Webhook URL is never stored or sent to our servers.</p>
             {error && <p className="text-xs text-rose-400">{error}</p>}
             <button
               type="submit"
               disabled={status === 'sending'}
-              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-[#6264f0] disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             >
               {status === 'sending' ? 'Sending…' : 'Send notification'}
             </button>

--- a/components/FindingCard.tsx
+++ b/components/FindingCard.tsx
@@ -149,7 +149,7 @@ export default function FindingCard({ finding, onMuteChange }: Props) {
       <div className="mt-4 flex items-center justify-between">
         <button
           onClick={handleMuteToggle}
-          className="text-xs text-slate-500 hover:text-slate-300 transition-colors"
+          className="text-xs text-slate-400 hover:text-slate-300 transition-colors"
         >
           {muted ? "Unmute this finding" : "Mute this finding"}
         </button>
@@ -157,7 +157,7 @@ export default function FindingCard({ finding, onMuteChange }: Props) {
           href={`https://github.com/Veritas-Vaults-Network/soroban-guard-core/issues/new?title=${encodeURIComponent(`False positive: ${finding.check_name}`)}&body=${encodeURIComponent(finding.description)}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-xs text-slate-500 hover:text-slate-300 transition-colors"
+          className="text-xs text-slate-400 hover:text-slate-300 transition-colors"
         >
           Report false positive
         </a>
@@ -177,7 +177,7 @@ function Detail({
 }) {
   return (
     <div className="rounded-md bg-[#1a1d27] px-3 py-2">
-      <p className="mb-0.5 text-xs text-slate-500">{label}</p>
+      <p className="mb-0.5 text-xs text-slate-400">{label}</p>
       <p
         className={`truncate text-sm text-slate-200 ${mono ? "font-mono" : ""}`}
         title={value}

--- a/components/FindingsByFile.tsx
+++ b/components/FindingsByFile.tsx
@@ -42,7 +42,7 @@ export default function FindingsByFile({ groupedFindings, onMuteChange }: Props)
             >
               <div className="flex items-center gap-3">
                 <svg
-                  className={`h-4 w-4 flex-shrink-0 text-slate-500 transition-transform ${
+                  className={`h-4 w-4 flex-shrink-0 text-slate-400 transition-transform ${
                     isExpanded ? 'rotate-90' : ''
                   }`}
                   fill="none"

--- a/components/FindingsByFunction.tsx
+++ b/components/FindingsByFunction.tsx
@@ -56,9 +56,9 @@ export default function FindingsByFunction({
                 <span className="truncate font-mono text-sm font-medium text-slate-200">{name}</span>
               </div>
               <div className="flex items-center gap-3 shrink-0">
-                <span className="text-xs text-slate-500">{items.length} finding{items.length !== 1 ? 's' : ''}</span>
+                <span className="text-xs text-slate-400">{items.length} finding{items.length !== 1 ? 's' : ''}</span>
                 <svg
-                  className={`h-4 w-4 text-slate-500 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                  className={`h-4 w-4 text-slate-400 transition-transform ${isOpen ? 'rotate-180' : ''}`}
                   fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />

--- a/components/FindingsDiff.tsx
+++ b/components/FindingsDiff.tsx
@@ -27,7 +27,7 @@ function DiffRow({ finding, variant }: { finding: Finding; variant: 'resolved' |
       ? 'text-green-400 font-bold'
       : variant === 'added'
         ? 'text-red-400 font-bold'
-        : 'text-slate-600'
+        : 'text-slate-400'
 
   return (
     <div className={`flex items-start gap-3 rounded-lg border px-4 py-3 ${rowClass}`}>
@@ -37,7 +37,7 @@ function DiffRow({ finding, variant }: { finding: Finding; variant: 'resolved' |
           <SeverityBadge severity={finding.severity} size="sm" />
           <span className={`text-sm font-medium ${textClass}`}>{finding.check_name}</span>
         </div>
-        <p className={`mt-1 text-xs ${variant === 'resolved' ? 'text-slate-500 line-through' : 'text-slate-400'}`}>
+        <p className={`mt-1 text-xs ${variant === 'resolved' ? 'text-slate-400 line-through' : 'text-slate-400'}`}>
           {finding.file_path}:{finding.line} · {finding.function_name}
         </p>
       </div>
@@ -60,12 +60,12 @@ function Section({
     <div>
       <h3 className="mb-2 text-sm font-semibold text-slate-400">
         {title}{' '}
-        <span className="ml-1 rounded-full bg-[#1a1d27] px-2 py-0.5 text-xs text-slate-500">
+        <span className="ml-1 rounded-full bg-[#1a1d27] px-2 py-0.5 text-xs text-slate-400">
           {findings.length}
         </span>
       </h3>
       {findings.length === 0 ? (
-        <p className="rounded-lg border border-[var(--border)] px-4 py-3 text-sm text-slate-500">{emptyText}</p>
+        <p className="rounded-lg border border-[var(--border)] px-4 py-3 text-sm text-slate-400">{emptyText}</p>
       ) : (
         <div className="flex flex-col gap-2">
           {findings.map((f, i) => (

--- a/components/FindingsFilterBar.tsx
+++ b/components/FindingsFilterBar.tsx
@@ -82,7 +82,7 @@ export default function FindingsFilterBar({ findings, filterState, onFilterChang
             >
               <SeverityBadge severity={severity} size="sm" includeIcon={false} />
               <span>{severity}</span>
-              <span className="ml-0.5 rounded-md bg-[var(--bg)] px-1.5 py-0.5 text-[10px] tabular-nums text-slate-500">
+              <span className="ml-0.5 rounded-md bg-[var(--bg)] px-1.5 py-0.5 text-[10px] tabular-nums text-slate-400">
                 {count}
               </span>
             </button>
@@ -93,7 +93,7 @@ export default function FindingsFilterBar({ findings, filterState, onFilterChang
       {/* File name filter */}
       <div className="relative min-w-[160px]">
         <svg
-          className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-500"
+          className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-400"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -107,12 +107,12 @@ export default function FindingsFilterBar({ findings, filterState, onFilterChang
           value={fileFilter}
           onChange={e => handleFileChange(e.target.value)}
           placeholder="Filter by file..."
-          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] py-1.5 pl-8 pr-2 text-xs text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] py-1.5 pl-8 pr-2 text-xs text-slate-200 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
         />
         {fileFilter && (
           <button
             onClick={() => handleFileChange('')}
-            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-white"
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white"
           >
             <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -138,7 +138,7 @@ export default function FindingsFilterBar({ findings, filterState, onFilterChang
       {hasActiveFilters && (
         <button
           onClick={handleClear}
-          className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs text-slate-500 transition-colors hover:text-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+          className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs text-slate-400 transition-colors hover:text-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
         >
           Clear filters
         </button>

--- a/components/FindingsSkeleton.tsx
+++ b/components/FindingsSkeleton.tsx
@@ -3,7 +3,7 @@ export default function FindingsSkeleton() {
   return (
     <div className="overflow-hidden rounded-xl border border-[#2a2d3a]">
       {/* Table header visually present to preserve layout */}
-      <div className="hidden grid-cols-[120px_1fr_1fr_80px_1fr] gap-4 border-b border-[#2a2d3a] bg-[#12151f] px-5 py-3 text-xs font-semibold uppercase tracking-wider text-slate-500 sm:grid">
+      <div className="hidden grid-cols-[120px_1fr_1fr_80px_1fr] gap-4 border-b border-[#2a2d3a] bg-[#12151f] px-5 py-3 text-xs font-semibold uppercase tracking-wider text-slate-400 sm:grid">
         <span>Severity</span>
         <span>Check</span>
         <span>Function</span>
@@ -22,7 +22,7 @@ export default function FindingsSkeleton() {
               </div>
               <div className="h-4 w-full rounded bg-[#1a1d27] animate-pulse" />
             </div>
-            <svg className="h-4 w-4 text-slate-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <svg className="h-4 w-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
             </svg>
           </div>
@@ -35,7 +35,7 @@ export default function FindingsSkeleton() {
             <span className="h-4 w-12 rounded bg-[#1a1d27] animate-pulse" />
             <div className="flex items-center justify-between gap-2">
               <span className="h-4 w-full rounded bg-[#1a1d27] animate-pulse" />
-              <svg className="h-4 w-4 text-slate-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+              <svg className="h-4 w-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
               </svg>
             </div>

--- a/components/FindingsTable.tsx
+++ b/components/FindingsTable.tsx
@@ -142,7 +142,7 @@ export default function FindingsTable({ findings, searchQuery = '', pageSize = 2
 
   function SortIndicator({ columnKey }: { columnKey: SortKey }) {
     if (sortConfig.key !== columnKey) {
-      return <span className="ml-1 inline-block text-slate-600">&#x21D5;</span>
+      return <span className="ml-1 inline-block text-slate-400">&#x21D5;</span>
     }
     return (
       <span className="ml-1 inline-block text-indigo-400">
@@ -155,14 +155,14 @@ export default function FindingsTable({ findings, searchQuery = '', pageSize = 2
 
     <div>
       {sorted.length === 0 ? (
-        <div className="rounded-xl border border-[var(--border)] bg-[var(--bg-tertiary)] px-5 py-10 text-center text-sm text-slate-500">
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--bg-tertiary)] px-5 py-10 text-center text-sm text-slate-400">
           No findings match your search.
         </div>
       ) : (
         <>
           <div className="overflow-hidden rounded-xl border border-[var(--border)]" role="table" aria-label="Scan findings">
             {/* Sortable table header */}
-            <div className="hidden grid-cols-[120px_1fr_1fr_80px_1fr] gap-4 border-b border-[var(--border)] bg-[var(--bg-tertiary)] px-5 py-3 text-xs font-semibold uppercase tracking-wider text-slate-500 sm:grid" role="row">
+            <div className="hidden grid-cols-[120px_1fr_1fr_80px_1fr] gap-4 border-b border-[var(--border)] bg-[var(--bg-tertiary)] px-5 py-3 text-xs font-semibold uppercase tracking-wider text-slate-400 sm:grid" role="row">
               {columns.map(col => (
                 <button
                   key={col.key}
@@ -206,7 +206,7 @@ export default function FindingsTable({ findings, searchQuery = '', pageSize = 2
                     <div className="hidden grid-cols-[120px_1fr_1fr_80px_1fr] items-center gap-4 sm:grid">
                       <div className="flex items-center gap-2" role="cell">
                         <SeverityBadge severity={finding.severity} size="sm" />
-                        <span className="text-xs font-semibold text-slate-500 uppercase tracking-wide" aria-hidden="true">{finding.severity}</span>
+                        <span className="text-xs font-semibold text-slate-400 uppercase tracking-wide" aria-hidden="true">{finding.severity}</span>
                       </div>
                       <div role="cell">
                         <CheckTooltip checkName={finding.check_name} />
@@ -230,7 +230,7 @@ export default function FindingsTable({ findings, searchQuery = '', pageSize = 2
           </div>
           {totalPages > 1 && (
             <div className="mt-6 flex items-center justify-between">
-              <p className="text-sm text-slate-500">
+              <p className="text-sm text-slate-400">
                 Showing {start + 1}&#8211;{Math.min(end, sorted.length)} of {sorted.length}
               </p>
               <div className="flex gap-2">
@@ -269,7 +269,7 @@ export default function FindingsTable({ findings, searchQuery = '', pageSize = 2
 function ChevronIcon({ expanded }: { expanded: boolean }) {
   return (
     <svg
-      className={`h-4 w-4 flex-shrink-0 text-slate-500 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+      className={`h-4 w-4 flex-shrink-0 text-slate-400 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"

--- a/components/GithubExportModal.tsx
+++ b/components/GithubExportModal.tsx
@@ -61,7 +61,7 @@ export default function GithubExportModal({ findings, onClose }: Props) {
       >
         <div className="mb-5 flex items-center justify-between">
           <h2 id={titleId} className="text-base font-semibold text-white">Create GitHub Issues</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded" aria-label="Close dialog">
+          <button onClick={onClose} className="text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded" aria-label="Close dialog">
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -80,7 +80,7 @@ export default function GithubExportModal({ findings, onClose }: Props) {
                 </li>
               ))}
             </ul>
-            <button onClick={onClose} className="mt-2 w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500">
+            <button onClick={onClose} className="mt-2 w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-[#6264f0]">
               Done
             </button>
           </div>
@@ -93,16 +93,16 @@ export default function GithubExportModal({ findings, onClose }: Props) {
                 onChange={e => setOwner(e.target.value)}
                 placeholder="owner"
                 disabled={busy}
-                className="flex-1 rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+                className="flex-1 rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
               />
-              <span className="flex items-center text-slate-500">/</span>
+              <span className="flex items-center text-slate-400">/</span>
               <input
                 required
                 value={repo}
                 onChange={e => setRepo(e.target.value)}
                 placeholder="repo"
                 disabled={busy}
-                className="flex-1 rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+                className="flex-1 rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
               />
             </div>
             <input
@@ -112,9 +112,9 @@ export default function GithubExportModal({ findings, onClose }: Props) {
               onChange={e => setToken(e.target.value)}
               placeholder="GitHub Personal Access Token"
               disabled={busy}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
-            <p className="text-xs text-slate-500">Token requires <code className="rounded bg-[#1a1d27] px-1 text-slate-400">repo</code> scope. It is never stored.</p>
+            <p className="text-xs text-slate-400">Token requires <code className="rounded bg-[#1a1d27] px-1 text-slate-400">repo</code> scope. It is never stored.</p>
 
             {error && <p className="text-xs text-rose-400">{error}</p>}
 
@@ -133,7 +133,7 @@ export default function GithubExportModal({ findings, onClose }: Props) {
             <button
               type="submit"
               disabled={busy}
-              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-[#6264f0] disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             >
               {busy ? 'Creating…' : `Create ${findings.length} issue${findings.length !== 1 ? 's' : ''}`}
             </button>

--- a/components/JiraExportModal.tsx
+++ b/components/JiraExportModal.tsx
@@ -74,7 +74,7 @@ export default function JiraExportModal({ findings, onClose }: Props) {
       >
         <div className="mb-5 flex items-center justify-between">
           <h2 id={titleId} className="text-base font-semibold text-white">Create Jira Tickets</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded" aria-label="Close dialog">
+          <button onClick={onClose} className="text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded" aria-label="Close dialog">
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -93,7 +93,7 @@ export default function JiraExportModal({ findings, onClose }: Props) {
                 </li>
               ))}
             </ul>
-            <button onClick={onClose} className="mt-2 w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500">
+            <button onClick={onClose} className="mt-2 w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-[#6264f0]">
               Done
             </button>
           </div>
@@ -106,7 +106,7 @@ export default function JiraExportModal({ findings, onClose }: Props) {
               onChange={e => setBaseUrl(e.target.value)}
               placeholder="https://your-domain.atlassian.net"
               disabled={busy}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
             <input
               required
@@ -115,7 +115,7 @@ export default function JiraExportModal({ findings, onClose }: Props) {
               onChange={e => setEmail(e.target.value)}
               placeholder="Jira account email"
               disabled={busy}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
             <input
               required
@@ -124,7 +124,7 @@ export default function JiraExportModal({ findings, onClose }: Props) {
               onChange={e => setApiToken(e.target.value)}
               placeholder="Jira API token"
               disabled={busy}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
             <input
               required
@@ -132,10 +132,10 @@ export default function JiraExportModal({ findings, onClose }: Props) {
               onChange={e => setProjectKey(e.target.value.toUpperCase())}
               placeholder="Project key"
               disabled={busy}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm uppercase text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm uppercase text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
 
-            <p className="text-xs text-slate-500">
+            <p className="text-xs text-slate-400">
               Creates tickets for {ticketFindings.length} High/Critical finding{ticketFindings.length !== 1 ? 's' : ''}. The API token is not stored.
             </p>
 
@@ -156,7 +156,7 @@ export default function JiraExportModal({ findings, onClose }: Props) {
             <button
               type="submit"
               disabled={busy || ticketFindings.length === 0}
-              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-[#6264f0] disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             >
               {busy ? 'Creating...' : `Create ${ticketFindings.length} ticket${ticketFindings.length !== 1 ? 's' : ''}`}
             </button>

--- a/components/LinearExportModal.tsx
+++ b/components/LinearExportModal.tsx
@@ -53,7 +53,7 @@ export default function LinearExportModal({ findings, onClose }: Props) {
       <div ref={dialogRef} className="w-full max-w-md rounded-2xl border border-[#2a2d3a] bg-[#0e1117] p-6 shadow-xl">
         <div className="mb-5 flex items-center justify-between">
           <h2 className="text-base font-semibold text-white">Create Linear Issues</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-white" aria-label="Close">
+          <button onClick={onClose} className="text-slate-400 hover:text-white" aria-label="Close">
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -72,7 +72,7 @@ export default function LinearExportModal({ findings, onClose }: Props) {
                 </li>
               ))}
             </ul>
-            <button onClick={onClose} className="mt-2 w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500">
+            <button onClick={onClose} className="mt-2 w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-[#6264f0]">
               Done
             </button>
           </div>
@@ -85,7 +85,7 @@ export default function LinearExportModal({ findings, onClose }: Props) {
               onChange={e => setApiKey(e.target.value)}
               placeholder="Linear API key"
               disabled={busy}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
             <input
               required
@@ -93,9 +93,9 @@ export default function LinearExportModal({ findings, onClose }: Props) {
               onChange={e => setTeamId(e.target.value)}
               placeholder="Linear team ID"
               disabled={busy}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
-            <p className="text-xs text-slate-500">
+            <p className="text-xs text-slate-400">
               Creates one Linear issue for each finding. The API key is not stored.
             </p>
 
@@ -116,7 +116,7 @@ export default function LinearExportModal({ findings, onClose }: Props) {
             <button
               type="submit"
               disabled={busy || findings.length === 0}
-              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-[#6264f0] disabled:cursor-not-allowed disabled:opacity-40"
             >
               {busy ? 'Creating...' : `Create ${findings.length} issue${findings.length !== 1 ? 's' : ''}`}
             </button>

--- a/components/NetworkHealthBanner.tsx
+++ b/components/NetworkHealthBanner.tsx
@@ -33,21 +33,21 @@ export default function NetworkHealthBanner({ network, onDismiss, checkHealth }:
     <div className="border-b border-amber-500/30 bg-amber-500/10 px-4 py-3 sm:px-6">
       <div className="mx-auto flex max-w-6xl items-start justify-between gap-3">
         <div className="flex items-start gap-3">
-          <svg className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-500" fill="currentColor" viewBox="0 0 24 24">
+          <svg className="mt-0.5 h-5 w-5 flex-shrink-0 text-[var(--warning-icon)]" fill="currentColor" viewBox="0 0 24 24">
             <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
           </svg>
           <div>
-            <p className="text-sm font-medium text-amber-900 dark:text-amber-200">
+            <p className="text-sm font-medium text-[var(--warning-text)]">
               Stellar {network} RPC is currently unreachable
             </p>
-            <p className="mt-1 text-xs text-amber-800 dark:text-amber-300">
+            <p className="mt-1 text-xs text-[var(--warning-text-secondary)]">
               Contract ID scanning may fail. Please try again later.
             </p>
           </div>
         </div>
         <button
           onClick={handleDismiss}
-          className="flex-shrink-0 text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
+          className="flex-shrink-0 text-[var(--warning-dismiss)] hover:text-[var(--warning-dismiss-hover)]"
           aria-label="Dismiss"
         >
           <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/components/NetworkSelector.tsx
+++ b/components/NetworkSelector.tsx
@@ -34,7 +34,7 @@ export default function NetworkSelector({ value, onChange }: Props) {
         id="network-selector"
         value={value.name}
         onChange={handleChange}
-        className="rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-2 py-1 text-xs text-slate-300 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
+        className="rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-2 py-1 text-xs text-slate-300 outline-none transition focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500"
       >
         <option value="mainnet">Mainnet</option>
         <option value="testnet">Testnet</option>

--- a/components/NotionExportModal.tsx
+++ b/components/NotionExportModal.tsx
@@ -53,7 +53,7 @@ export default function NotionExportModal({ findings, onClose }: Props) {
       >
         <div className="mb-5 flex items-center justify-between">
           <h2 id={titleId} className="text-base font-semibold text-white">Export to Notion</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded" aria-label="Close dialog">
+          <button onClick={onClose} className="text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded" aria-label="Close dialog">
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -73,7 +73,7 @@ export default function NotionExportModal({ findings, onClose }: Props) {
             </a>
             <button
               onClick={onClose}
-              className="w-full rounded-lg bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500"
+              className="w-full rounded-lg bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-[#6264f0]"
             >
               Done
             </button>
@@ -91,9 +91,9 @@ export default function NotionExportModal({ findings, onClose }: Props) {
                 value={token}
                 onChange={e => setToken(e.target.value)}
                 placeholder="secret_..."
-                className="w-full rounded-lg border border-[#2a2d3a] bg-[#161922] px-3 py-2 text-sm text-white placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full rounded-lg border border-[#2a2d3a] bg-[#161922] px-3 py-2 text-sm text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
-              <p className="mt-1 text-xs text-slate-600">Never stored — used only for this request.</p>
+              <p className="mt-1 text-xs text-slate-400">Never stored — used only for this request.</p>
             </div>
             <div>
               <label className="mb-1 block text-xs text-slate-400" htmlFor="notion-db">
@@ -106,14 +106,14 @@ export default function NotionExportModal({ findings, onClose }: Props) {
                 value={databaseId}
                 onChange={e => setDatabaseId(e.target.value)}
                 placeholder="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-                className="w-full rounded-lg border border-[#2a2d3a] bg-[#161922] px-3 py-2 text-sm text-white placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full rounded-lg border border-[#2a2d3a] bg-[#161922] px-3 py-2 text-sm text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
             </div>
             {error && <p className="text-xs text-red-400">{error}</p>}
             <button
               type="submit"
               disabled={loading}
-              className="w-full rounded-lg bg-indigo-600 py-2 text-sm font-medium text-white transition hover:bg-indigo-500 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              className="w-full rounded-lg bg-indigo-600 py-2 text-sm font-medium text-white transition hover:bg-[#6264f0] disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             >
               {loading ? 'Creating page…' : 'Create Notion page'}
             </button>

--- a/components/RecentScansPanel.tsx
+++ b/components/RecentScansPanel.tsx
@@ -54,7 +54,7 @@ export default function RecentScansPanel({ onLaunch }: Props) {
 
   if (scans.length === 0 && !query) {
     return (
-      <nav aria-label="Recent scans" className="mt-4 py-4 text-center text-sm text-slate-500">
+      <nav aria-label="Recent scans" className="mt-4 py-4 text-center text-sm text-slate-400">
         Your recent scans will appear here.
       </nav>
     )
@@ -69,7 +69,7 @@ export default function RecentScansPanel({ onLaunch }: Props) {
       {/* Search */}
       <div className="mb-3 flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2">
         <svg
-          className="h-4 w-4 shrink-0 text-slate-500"
+          className="h-4 w-4 shrink-0 text-slate-400"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -87,18 +87,18 @@ export default function RecentScansPanel({ onLaunch }: Props) {
           placeholder="Search recent scans…"
           value={query}
           onChange={e => setQuery(e.target.value)}
-          className="w-full bg-transparent text-sm text-slate-300 placeholder-slate-600 outline-none"
+          className="w-full bg-transparent text-sm text-slate-300 placeholder-slate-400 outline-none"
           aria-label="Search recent scans"
         />
       </div>
 
       {filtered.length === 0 && (
-        <p className="py-4 text-center text-sm text-slate-500">No matches found.</p>
+        <p className="py-4 text-center text-sm text-slate-400">No matches found.</p>
       )}
 
       {pinnedScans.length > 0 && (
         <div className="mb-3">
-          <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-slate-600">
+          <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
             📌 Pinned
           </p>
           <ul className="space-y-1">
@@ -120,7 +120,7 @@ export default function RecentScansPanel({ onLaunch }: Props) {
       {recentScans.length > 0 && (
         <div>
           {pinnedScans.length > 0 && (
-            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-slate-600">
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
               Recent
             </p>
           )}
@@ -173,12 +173,12 @@ function ScanRow({
             {scan.network}
           </span>
         )}
-        <span className="shrink-0 text-xs text-slate-600">{formatRelative(scan.timestamp)}</span>
+        <span className="shrink-0 text-xs text-slate-400">{formatRelative(scan.timestamp)}</span>
       </button>
 
       <button
         onClick={() => (isPinned ? onUnpin(scan.value) : onPin(scan.value))}
-        className="shrink-0 rounded p-1 text-slate-600 transition hover:text-amber-400"
+        className="shrink-0 rounded p-1 text-slate-400 transition hover:text-amber-400"
         aria-label={isPinned ? 'Unpin scan' : 'Pin scan'}
         title={isPinned ? 'Unpin' : 'Pin'}
       >
@@ -187,7 +187,7 @@ function ScanRow({
 
       <button
         onClick={() => onRemove(scan)}
-        className="shrink-0 rounded p-1 text-slate-600 opacity-0 transition hover:text-red-400 group-hover:opacity-100 focus:opacity-100"
+        className="shrink-0 rounded p-1 text-slate-400 opacity-0 transition hover:text-red-400 group-hover:opacity-100 focus:opacity-100"
         aria-label={`Remove ${label} from recent scans`}
         title="Remove"
       >

--- a/components/ResultsQRCode.tsx
+++ b/components/ResultsQRCode.tsx
@@ -127,7 +127,7 @@ export default function ResultsQRCode({ url, isOpen, onClose }: ResultsQRCodePro
           <button
             ref={closeButtonRef}
             onClick={onClose}
-            className="text-slate-500 transition hover:text-white"
+            className="text-slate-400 transition hover:text-white"
             aria-label="Close"
           >
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -161,7 +161,7 @@ export default function ResultsQRCode({ url, isOpen, onClose }: ResultsQRCodePro
                   includeMargin
                 />
               </div>
-              <p className="w-full break-all text-center text-xs text-slate-500">{url}</p>
+              <p className="w-full break-all text-center text-xs text-slate-400">{url}</p>
             </div>
           )}
         </div>
@@ -177,7 +177,7 @@ export default function ResultsQRCode({ url, isOpen, onClose }: ResultsQRCodePro
             ref={downloadButtonRef}
             onClick={handleDownload}
             disabled={error !== null}
-            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-[#6264f0] disabled:cursor-not-allowed disabled:opacity-40"
           >
             Download QR
           </button>

--- a/components/ScanHeatmap.tsx
+++ b/components/ScanHeatmap.tsx
@@ -142,7 +142,7 @@ export default function ScanHeatmap({ entries, selectedDate, onDayClick }: Props
         {monthLabels.map(({ label, col }) => (
           <span
             key={`${label}-${col}`}
-            className="absolute text-[10px] text-slate-500"
+            className="absolute text-[10px] text-slate-400"
             style={{ left: `calc(1.5rem + ${col} * 14px)` }}
           >
             {label}
@@ -156,7 +156,7 @@ export default function ScanHeatmap({ entries, selectedDate, onDayClick }: Props
           {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, i) => (
             <span
               key={i}
-              className="flex h-[14px] items-center justify-end pr-1 text-[9px] text-slate-600"
+              className="flex h-[14px] items-center justify-end pr-1 text-[9px] text-slate-400"
             >
               {i % 2 === 1 ? d : ''}
             </span>
@@ -224,7 +224,7 @@ export default function ScanHeatmap({ entries, selectedDate, onDayClick }: Props
       </div>
 
       {/* Legend */}
-      <div className="mt-3 flex items-center gap-2 text-[10px] text-slate-500" aria-hidden="true">
+      <div className="mt-3 flex items-center gap-2 text-[10px] text-slate-400" aria-hidden="true">
         <span>Less</span>
         {(['none', 'Info', 'Low', 'Medium', 'High', 'Critical'] as DaySeverity[]).map(s => (
           <div key={s} className="flex items-center gap-1">

--- a/components/ScanInput.tsx
+++ b/components/ScanInput.tsx
@@ -328,7 +328,7 @@ export default function ScanInput({
                     : name === 'testnet'
                       ? 'border-amber-500/30 bg-amber-500/10 text-amber-400'
                       : 'border-violet-500/30 bg-violet-500/10 text-violet-400'
-                  : 'border-[#2a2d3a] text-slate-500 hover:text-slate-300'
+                  : 'border-[#2a2d3a] text-slate-400 hover:text-slate-300'
               }`}
             >
               <input
@@ -449,7 +449,7 @@ export default function ScanInput({
             onKeyDown={handleKeyDown}
             placeholder={`#![no_std]\nuse soroban_sdk::{contract, contractimpl, Env};\n\n#[contract]\npub struct MyContract;\n\n#[contractimpl]\nimpl MyContract {\n    pub fn hello(env: Env) -> String {\n        // paste your contract here...\n    }\n}`}
             rows={16}
-            className="code-textarea w-full resize-y rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 text-slate-300 placeholder-slate-600 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
+            className="code-textarea w-full resize-y rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 text-slate-300 placeholder-slate-400 outline-none transition focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500"
             spellCheck={false}
             disabled={loading}
           />
@@ -461,7 +461,7 @@ export default function ScanInput({
                   ? "text-red-400"
                   : code.length > MAX_CHARS / 2
                     ? "text-amber-400"
-                    : "text-slate-600"
+                    : "text-slate-400"
               }`}
             >
               {t('scanInput.code.charCount', {
@@ -489,10 +489,10 @@ export default function ScanInput({
             onChange={(e) => setRepoUrl(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="https://github.com/org/repo"
-            className={`w-full rounded-xl border px-4 py-3 text-slate-300 placeholder-slate-600 outline-none transition bg-[#12151f] ${
+            className={`w-full rounded-xl border px-4 py-3 text-slate-300 placeholder-slate-400 outline-none transition bg-[#12151f] ${
               repoUrl && !repoValidation.valid
-                ? "border-red-500/50 focus:border-red-500/60 focus:ring-1 focus:ring-red-500/30"
-                : "border-[#2a2d3a] focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
+                ? "border-red-500/50 focus:border-red-500/60 focus:ring-2 focus:ring-red-500"
+                : "border-[#2a2d3a] focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500"
             }`}
             disabled={loading}
           />
@@ -514,7 +514,7 @@ export default function ScanInput({
             </div>
           )}
           {!repoError && (
-            <p className="text-xs text-slate-500">
+            <p className="text-xs text-slate-400">
               {t('scanInput.github.hint').split('.rs').map((part, i, arr) =>
                 i < arr.length - 1 ? (
                   <span key={i}>{part}<code className="rounded bg-[#1a1d27] px-1 text-slate-400">.rs</code></span>
@@ -534,7 +534,7 @@ export default function ScanInput({
               onChange={(e) => handleContractIdChange(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-              className="w-full rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 font-mono text-sm text-slate-300 placeholder-slate-600 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
+              className="w-full rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 font-mono text-sm text-slate-300 placeholder-slate-400 outline-none transition focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500"
               disabled={loading}
               spellCheck={false}
             />
@@ -554,7 +554,7 @@ export default function ScanInput({
               WASM size: {wasmSize.toLocaleString()} bytes ({(wasmSize / 1024).toFixed(1)} KB)
             </p>
           )}
-          <p className="text-xs text-slate-500">
+          <p className="text-xs text-slate-400">
             {t('scanInput.contractId.hint')}
           </p>
         </div>
@@ -567,7 +567,7 @@ export default function ScanInput({
               onChange={(e) => handleCidChange(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="Qm… or bafy…"
-              className="flex-1 rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 font-mono text-sm text-slate-300 placeholder-slate-600 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
+              className="flex-1 rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 font-mono text-sm text-slate-300 placeholder-slate-400 outline-none transition focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500"
               disabled={loading || ipfsFetching}
               spellCheck={false}
             />
@@ -607,7 +607,7 @@ export default function ScanInput({
           </div>
           {ipfsError && <p className="text-xs text-rose-400">{ipfsError}</p>}
           {!ipfsError && !ipfsPreview && (
-            <p className="text-xs text-slate-500">
+            <p className="text-xs text-slate-400">
               {t('scanInput.ipfs.hint').split('Qm…').map((part, i, arr) =>
                 i < arr.length - 1 ? (
                   <span key={i}>{part}<code className="rounded bg-[#1a1d27] px-1 text-slate-400">Qm…</code></span>
@@ -651,7 +651,7 @@ export default function ScanInput({
               }}
               onKeyDown={handleKeyDown}
               placeholder="https://gist.github.com/user/abc123"
-              className="flex-1 rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 text-slate-300 placeholder-slate-600 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30"
+              className="flex-1 rounded-xl border border-[#2a2d3a] bg-[#12151f] px-4 py-3 text-slate-300 placeholder-slate-400 outline-none transition focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500"
               disabled={loading || gistFetching}
             />
             <button
@@ -690,7 +690,7 @@ export default function ScanInput({
           </div>
           {gistError && <p className="text-xs text-rose-400">{gistError}</p>}
           {!gistError && gistFiles.length === 0 && (
-            <p className="text-xs text-slate-500">
+            <p className="text-xs text-slate-400">
               {t('scanInput.gist.hint')}
             </p>
           )}
@@ -699,7 +699,7 @@ export default function ScanInput({
             <div className="space-y-1">
               <label
                 htmlFor="gist-file-select"
-                className="text-xs text-slate-500"
+                className="text-xs text-slate-400"
               >
                 {t('scanInput.gist.selectFile')}
               </label>
@@ -801,7 +801,7 @@ export default function ScanInput({
               }}
               placeholder={t('scanInput.advanced.slackPlaceholder')}
               disabled={loading}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#0a0c0f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none transition focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#0a0c0f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none transition focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
             <p className="text-xs font-medium text-slate-400 mt-3">
               {t('scanInput.advanced.telegramLabel')}
@@ -815,7 +815,7 @@ export default function ScanInput({
                   localStorage.setItem(TG_BOT_TOKEN_KEY, e.target.value);
                 }}
                 placeholder={t('scanInput.advanced.telegramBotPlaceholder')}
-                className="w-full rounded-lg border border-[#2a2d3a] bg-[#0d0f17] px-3 py-2 text-xs text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60"
+                className="w-full rounded-lg border border-[#2a2d3a] bg-[#0d0f17] px-3 py-2 text-xs text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60"
                 disabled={loading}
               />
               <input
@@ -826,10 +826,10 @@ export default function ScanInput({
                   localStorage.setItem(TG_CHAT_ID_KEY, e.target.value);
                 }}
                 placeholder={t('scanInput.advanced.telegramChatPlaceholder')}
-                className="w-full rounded-lg border border-[#2a2d3a] bg-[#0d0f17] px-3 py-2 text-xs text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60"
+                className="w-full rounded-lg border border-[#2a2d3a] bg-[#0d0f17] px-3 py-2 text-xs text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60"
                 disabled={loading}
               />
-              <p className="text-xs text-slate-600">
+              <p className="text-xs text-slate-400">
                 {t('scanInput.advanced.telegramHint')}
               </p>
             </div>
@@ -865,7 +865,7 @@ export default function ScanInput({
           <button
             type="submit"
             disabled={!canSubmit}
-            className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white transition hover:bg-[#6264f0] disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
           >
             {isRateLimited ? (
               <>
@@ -932,7 +932,7 @@ export default function ScanInput({
             className={`flex items-center justify-center rounded-xl border px-3 py-3 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
               notificationsEnabled
                 ? "border-indigo-500/60 bg-indigo-500/10 text-indigo-300 hover:bg-indigo-500/20"
-                : "border-[#2a2d3a] bg-[#12151f] text-slate-500 hover:text-slate-300"
+                : "border-[#2a2d3a] bg-[#12151f] text-slate-400 hover:text-slate-300"
             }`}
           >
             {notificationsEnabled ? (
@@ -966,7 +966,7 @@ export default function ScanInput({
             )}
           </button>
         </div>
-        <p className="text-center text-xs text-slate-600">{t('scanInput.submit.shortcut')}</p>
+        <p className="text-center text-xs text-slate-400">{t('scanInput.submit.shortcut')}</p>
       </div>
     </form>
   );

--- a/components/ScanProgress.tsx
+++ b/components/ScanProgress.tsx
@@ -82,7 +82,7 @@ export default function ScanProgress({ loading, batchCurrent, batchTotal }: Prop
       {/* Header with indicator that progress is estimated */}
       <div className="flex items-center justify-between gap-2 px-1">
         {!isBatch && (
-          <span className="text-xs font-medium text-slate-500">Estimated progress</span>
+          <span className="text-xs font-medium text-slate-400">Estimated progress</span>
         )}
         {!isBatch && (
           <div
@@ -90,7 +90,7 @@ export default function ScanProgress({ loading, batchCurrent, batchTotal }: Prop
             title="Progress times are estimated. Actual scan duration depends on contract complexity."
           >
             <svg
-              className="h-4 w-4 text-slate-500 transition-colors group-hover:text-slate-400"
+              className="h-4 w-4 text-slate-400 transition-colors group-hover:text-slate-300"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -152,7 +152,7 @@ export default function ScanProgress({ loading, batchCurrent, batchTotal }: Prop
                     ? 'bg-indigo-600 text-white'
                     : active
                       ? 'bg-indigo-500/30 text-indigo-300 ring-2 ring-indigo-500'
-                      : 'bg-[#1a1d27] text-slate-600 ring-1 ring-[#2a2d3a]'
+                      : 'bg-[#1a1d27] text-slate-400 ring-1 ring-[#2a2d3a]'
                 }`}
               >
                 {done ? (
@@ -169,12 +169,12 @@ export default function ScanProgress({ loading, batchCurrent, batchTotal }: Prop
               </div>
               <span
                 className={`text-xs transition-colors duration-500 ${
-                  done ? 'text-indigo-400' : active ? 'text-white' : 'text-slate-600'
+                  done ? 'text-indigo-400' : active ? 'text-white' : 'text-slate-400'
                 }`}
               >
                 {label}
                 {stepDuration && (
-                  <span className="ml-1 text-slate-500">— {stepDuration}</span>
+                  <span className="ml-1 text-slate-400">— {stepDuration}</span>
                 )}
                 {liveElapsed && (
                   <span className="ml-1 text-slate-400">{liveElapsed}</span>
@@ -187,7 +187,7 @@ export default function ScanProgress({ loading, batchCurrent, batchTotal }: Prop
 
       {/* Percentage label (single scan only) */}
       {!isBatch && (
-        <p className="text-center text-xs text-slate-500">
+        <p className="text-center text-xs text-slate-400">
           {pct}% estimated
         </p>
       )}

--- a/components/ScanQuota.tsx
+++ b/components/ScanQuota.tsx
@@ -20,7 +20,7 @@ export default function ScanQuotaIndicator({ quota }: { quota: ScanQuota }) {
 
   return (
     <div className="mt-4 space-y-1.5">
-      <div className="flex items-center justify-between text-xs text-slate-500">
+      <div className="flex items-center justify-between text-xs text-slate-400">
         <span>
           <span className={low ? 'font-semibold text-red-400' : 'text-slate-400'}>{remaining}</span>
           {' '}of {quota.limit} scans remaining today

--- a/components/SeverityDonut.tsx
+++ b/components/SeverityDonut.tsx
@@ -53,7 +53,7 @@ export default function SeverityDonut({ counts }: Props) {
         </ResponsiveContainer>
         <div className="absolute inset-0 flex flex-col items-center justify-center">
           <span className="text-2xl font-bold text-white">{total}</span>
-          <span className="text-xs text-slate-500">findings</span>
+          <span className="text-xs text-slate-400">findings</span>
         </div>
       </div>
     </figure>

--- a/components/SeverityTrendChart.tsx
+++ b/components/SeverityTrendChart.tsx
@@ -56,13 +56,13 @@ export default function SeverityTrendChart({ data }: Props) {
           <BarChart data={data} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
             <XAxis
               dataKey="date"
-              tick={{ fill: '#64748b', fontSize: 11 }}
+              tick={{ fill: '#94a3b8', fontSize: 11 }}
               axisLine={false}
               tickLine={false}
             />
             <YAxis
               allowDecimals={false}
-              tick={{ fill: '#64748b', fontSize: 11 }}
+              tick={{ fill: '#94a3b8', fontSize: 11 }}
               axisLine={false}
               tickLine={false}
             />

--- a/components/SlackNotifyModal.tsx
+++ b/components/SlackNotifyModal.tsx
@@ -50,7 +50,7 @@ export default function SlackNotifyModal({ findings, source, onClose }: Props) {
       >
         <div className="mb-5 flex items-center justify-between">
           <h2 id={titleId} className="text-base font-semibold text-white">Send to Slack</h2>
-          <button onClick={onClose} aria-label="Close dialog" className="rounded text-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+          <button onClick={onClose} aria-label="Close dialog" className="rounded text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -60,7 +60,7 @@ export default function SlackNotifyModal({ findings, source, onClose }: Props) {
         {status === 'done' ? (
           <div className="space-y-3">
             <p className="text-sm text-emerald-400">✓ Scan results sent to Slack</p>
-            <button onClick={onClose} className="w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500">
+            <button onClick={onClose} className="w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-[#6264f0]">
               Done
             </button>
           </div>
@@ -72,14 +72,14 @@ export default function SlackNotifyModal({ findings, source, onClose }: Props) {
               onChange={e => setWebhookUrl(e.target.value)}
               placeholder="Slack Incoming Webhook URL"
               disabled={status === 'sending'}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
-            <p className="text-xs text-slate-500">Webhook URL is never stored or sent to our servers.</p>
+            <p className="text-xs text-slate-400">Webhook URL is never stored or sent to our servers.</p>
             {error && <p className="text-xs text-rose-400">{error}</p>}
             <button
               type="submit"
               disabled={status === 'sending'}
-              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-[#6264f0] disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             >
               {status === 'sending' ? 'Sending…' : 'Send notification'}
             </button>

--- a/components/TelegramNotifyModal.tsx
+++ b/components/TelegramNotifyModal.tsx
@@ -51,7 +51,7 @@ export default function TelegramNotifyModal({ findings, source, onClose }: Props
       >
         <div className="mb-5 flex items-center justify-between">
           <h2 id={titleId} className="text-base font-semibold text-white">Send to Telegram</h2>
-          <button onClick={onClose} aria-label="Close dialog" className="rounded text-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+          <button onClick={onClose} aria-label="Close dialog" className="rounded text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -61,7 +61,7 @@ export default function TelegramNotifyModal({ findings, source, onClose }: Props
         {status === 'done' ? (
           <div className="space-y-3">
             <p className="text-sm text-emerald-400">✓ Scan results sent to Telegram</p>
-            <button onClick={onClose} className="w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-500">
+            <button onClick={onClose} className="w-full rounded-xl bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-[#6264f0]">
               Done
             </button>
           </div>
@@ -74,7 +74,7 @@ export default function TelegramNotifyModal({ findings, source, onClose }: Props
               onChange={e => setBotToken(e.target.value)}
               placeholder="Bot Token (from @BotFather)"
               disabled={status === 'sending'}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
             <input
               required
@@ -82,14 +82,14 @@ export default function TelegramNotifyModal({ findings, source, onClose }: Props
               onChange={e => setChatId(e.target.value)}
               placeholder="Chat ID (e.g. -1001234567890)"
               disabled={status === 'sending'}
-              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-600 outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30 disabled:opacity-50"
+              className="w-full rounded-lg border border-[#2a2d3a] bg-[#12151f] px-3 py-2 text-sm text-slate-300 placeholder-slate-400 outline-none focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
             />
-            <p className="text-xs text-slate-500">Token is never stored or sent to our servers.</p>
+            <p className="text-xs text-slate-400">Token is never stored or sent to our servers.</p>
             {error && <p className="text-xs text-rose-400">{error}</p>}
             <button
               type="submit"
               disabled={status === 'sending'}
-              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              className="w-full rounded-xl bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-[#6264f0] disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             >
               {status === 'sending' ? 'Sending…' : 'Send notification'}
             </button>

--- a/components/TourTooltip.tsx
+++ b/components/TourTooltip.tsx
@@ -216,7 +216,7 @@ export default function TourTooltip({
         <div className="flex items-center justify-between gap-2">
           <button
             onClick={onSkip}
-            className="text-xs text-slate-500 underline-offset-2 hover:text-slate-300 hover:underline"
+            className="text-xs text-slate-400 underline-offset-2 hover:text-slate-300 hover:underline"
           >
             Skip tour
           </button>
@@ -231,7 +231,7 @@ export default function TourTooltip({
             )}
             <button
               onClick={onNext}
-              className="rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-indigo-500"
+              className="rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-[#6264f0]"
             >
               {stepIndex < total - 1 ? 'Next →' : 'Done'}
             </button>

--- a/components/WalletConnect.tsx
+++ b/components/WalletConnect.tsx
@@ -54,14 +54,14 @@ export default function WalletConnect() {
           <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
           <ContractIdBadge id={publicKey} className="text-xs text-emerald-400" />
           {network && (
-            <span className="rounded-full bg-[#1a1d27] px-1.5 py-0.5 text-xs text-slate-500">
+            <span className="rounded-full bg-[#1a1d27] px-1.5 py-0.5 text-xs text-slate-400">
               {network.name}
             </span>
           )}
         </div>
         <button
           onClick={disconnect}
-          className="text-xs text-slate-500 hover:text-slate-300"
+          className="text-xs text-slate-400 hover:text-slate-300"
         >
           Disconnect
         </button>

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, type Page } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+const mockFindings = JSON.stringify({
+  findings: [
+    {
+      check_name: 'unchecked-auth',
+      severity: 'Critical',
+      file_path: 'src/lib.rs',
+      line: 42,
+      function_name: 'transfer',
+      description: 'Authorization is not verified before executing privileged operation.',
+      remediation: 'Require require_auth() before mutating balances.',
+    },
+    {
+      check_name: 'integer-overflow',
+      severity: 'Medium',
+      file_path: 'src/lib.rs',
+      line: 85,
+      function_name: 'add_balance',
+      description: 'Integer arithmetic may overflow without bounds checking.',
+    },
+  ],
+})
+
+// Skip the first-visit splash screen and onboarding tour overlays — they're
+// unrelated to contrast auditing and their animated backdrops intercept clicks.
+function skipOnboarding(page: Page) {
+  return page.addInitScript(`
+    (() => {
+      sessionStorage.setItem('sg_splash_seen', '1');
+      localStorage.setItem('sg_tour_seen', '1');
+    })();
+  `)
+}
+
+function mockScanFetch(page: Page) {
+  return page.addInitScript(`
+    (() => {
+      if (!navigator.clipboard) {
+        navigator.clipboard = { writeText: () => Promise.resolve(), readText: () => Promise.resolve('') };
+      }
+      const originalFetch = window.fetch;
+      window.fetch = async (input, init) => {
+        const url = typeof input === 'string' ? input : input.url;
+        if (url.includes('/scan') && init?.method === 'POST') {
+          return new Response(JSON.stringify(${mockFindings}), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return originalFetch(input, init);
+      };
+    })();
+  `)
+}
+
+// Only the color-contrast rule is asserted here — this suite is a targeted
+// regression guard for the WCAG AA contrast audit, not a full a11y sweep.
+async function expectNoContrastViolations(page: Page) {
+  const results = await new AxeBuilder({ page }).withRules(['color-contrast']).analyze()
+  expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([])
+}
+
+test.describe('WCAG AA color contrast', () => {
+  // The app now respects OS color-scheme on first load (#516). Playwright's
+  // default browser context is light, so without this the suite would audit
+  // the light theme instead of the dark theme it's meant to guard.
+  test.use({ colorScheme: 'dark' })
+
+  test('home page (dark theme default)', async ({ page }) => {
+    await skipOnboarding(page)
+    await page.goto('/')
+    await expect(page.locator('text=Find vulnerabilities')).toBeVisible()
+    await expectNoContrastViolations(page)
+  })
+
+  test('results page with findings', async ({ page }) => {
+    await skipOnboarding(page)
+    await mockScanFetch(page)
+    await page.goto('/')
+    await page.locator('textarea').first().fill('pub fn transfer() {}')
+    await page.locator('button:has-text("Scan Contract")').click()
+    await page.waitForURL(/\/results/)
+    await expect(page.locator('text=unchecked-auth:visible').first()).toBeVisible({ timeout: 15000 })
+
+    await expectNoContrastViolations(page)
+  })
+
+  test('notification modal (placeholder text, focus states)', async ({ page }) => {
+    await skipOnboarding(page)
+    await mockScanFetch(page)
+    await page.goto('/')
+    await page.locator('textarea').first().fill('pub fn transfer() {}')
+    await page.locator('button:has-text("Scan Contract")').click()
+    await page.waitForURL(/\/results/)
+
+    await page.locator('button:has-text("Notify Discord")').click()
+    const webhookInput = page.locator('input[placeholder="Discord Webhook URL"]')
+    await expect(webhookInput).toBeVisible()
+    await webhookInput.focus()
+
+    await expectNoContrastViolations(page)
+  })
+
+  test('history page (empty state)', async ({ page }) => {
+    await skipOnboarding(page)
+    await page.goto('/history')
+    await expectNoContrastViolations(page)
+  })
+})

--- a/lib/__tests__/history.test.ts
+++ b/lib/__tests__/history.test.ts
@@ -1,5 +1,6 @@
 import { addScanRecord, getScanHistory, getById, clearScanHistory, getAllScanHistory } from '../history'
 import { CONTRACT_SCAN_RECORD_SCHEMA_VERSION } from '@/types/stellar'
+import { SCORE_VERSION } from '../score'
 
 const STORAGE_KEY = 'sg_scan_history'
 

--- a/lib/history.ts
+++ b/lib/history.ts
@@ -1,5 +1,6 @@
 import type { ContractScanRecord } from '@/types/stellar'
 import { CONTRACT_SCAN_RECORD_SCHEMA_VERSION } from '@/types/stellar'
+import { SCORE_VERSION } from './score'
 
 const STORAGE_KEY = 'sg_scan_history'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "soroban-guard-sdk": "*"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.0",
         "@tailwindcss/postcss": "^4.3.1",
         "@testing-library/dom": "^10.4.1",
@@ -86,6 +87,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -772,9 +786,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2198,6 +2212,17 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
@@ -4266,9 +4291,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -9709,6 +9734,7 @@
       "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "soroban-guard-sdk": "*"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.0",
     "@tailwindcss/postcss": "^4.3.1",
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
closes #468 
…n guard

Bulk-corrects muted text/placeholder colors (text-slate-500/600/700, placeholder-slate-500/600) that fell below the 4.5:1 AA threshold against the app's dark backgrounds, standardizes weak focus-ring/border contrast in modal inputs to the 3:1 UI-component threshold, fixes NetworkHealthBanner (which relied on Tailwind dark: variants this app never activates, since theming is done via a data-theme attribute rather than a .dark class), and corrects a few hardcoded low-contrast hex colors (embed badge, chart axes).

Also repairs a broken Tailwind v4 pipeline in app/globals.css: the legacy `@tailwind base/components/utilities` directives were in use instead of `@import "tailwindcss"`, which meant no named color utility (text-slate-400, bg-indigo-600, text-white, etc.) compiled at all, in dev or production. Without this fix none of the contrast corrections above would take effect in the running app. Also fixes a missing SCORE_VERSION import in lib/history.ts (and its test) that was breaking `npm run build`.

Adds e2e/accessibility.spec.ts using @axe-core/playwright, scoped to the color-contrast rule, to catch future regressions.

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

Closes #

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Tested in browser (Chrome + Firefox)
- [ ] Mobile layout checked
- [ ] No `console.log` left in code
- [ ] Relevant docs updated
