### PR TITLE
fix: detect backend unavailability and degrade UI honestly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ API_SECRET_KEY=
 # Leave unset to fall back to in-memory storage (suitable for local dev).
 KV_REST_API_URL=
 KV_REST_API_TOKEN=
+
+# Production note: NEXT_PUBLIC_API_URL must be set in the Vercel project settings
+# (not just in .env.local) because it is inlined at build time.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Install [Freighter](https://freighter.app) in your browser to enable wallet feat
 
 Copy `.env.example` to `.env.local` and fill in the values.
 
+> **Production (Vercel):** `NEXT_PUBLIC_API_URL` is inlined at build time, so it must be set in the [Vercel project settings](https://vercel.com/docs/projects/environment-variables) or via `vercel env add NEXT_PUBLIC_API_URL`. Adding it to `.env.local` alone is not enough for production deployments.
+
 ## Internal API Authentication
 
 `POST/GET /api/results` and `POST/GET /api/webhook` are internal routes used to share scan results across page navigations and deliver webhook payloads.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import { NETWORKS } from '@/types/stellar'
 import { addRecent } from '@/lib/recentScans'
 import RecentScansPanel from '@/components/RecentScansPanel'
 import type { RecentScan } from '@/lib/recentScans'
+import ApiHealthBanner from '@/components/ApiHealthBanner'
 
 const TOUR_STEPS = [
   {
@@ -135,6 +136,8 @@ export default function HomePage() {
         const retryAfter = err.retryAfter ?? 60
         setQuota({ remaining: 0, limit: 0, resetAt: Date.now() + retryAfter * 1000 })
         setError(err.message)
+      } else if (err instanceof TypeError && err.message.includes('fetch')) {
+        setError('The scanner backend is unavailable. Please try again later.')
       } else {
         setError(err instanceof Error ? err.message : 'Unexpected error')
       }
@@ -156,6 +159,7 @@ export default function HomePage() {
       </div>
 
       {/* Network health banner */}
+      <ApiHealthBanner />
 
       {/* Nav */}
       <header className="border-b border-[var(--border)] bg-[var(--bg)]/80 backdrop-blur-sm">

--- a/components/ApiHealthBanner.tsx
+++ b/components/ApiHealthBanner.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { checkApiHealth } from '@/lib/api'
+
+interface Props {
+  onDismiss?: () => void
+}
+
+export default function ApiHealthBanner({ onDismiss }: Props) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    let mounted = true
+
+    async function ping() {
+      const healthy = await checkApiHealth()
+      if (mounted && !healthy) {
+        setVisible(true)
+      }
+    }
+
+    ping()
+
+    const id = setInterval(async () => {
+      const healthy = await checkApiHealth()
+      if (mounted && healthy) {
+        setVisible(false)
+        onDismiss?.()
+      }
+    }, 60_000)
+
+    return () => {
+      mounted = false
+      clearInterval(id)
+    }
+  }, [onDismiss])
+
+  function handleDismiss() {
+    setVisible(false)
+    onDismiss?.()
+  }
+
+  if (!visible) return null
+
+  return (
+    <div className="border-b border-amber-500/30 bg-amber-500/10 px-4 py-3 sm:px-6">
+      <div className="mx-auto flex max-w-6xl items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <svg className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-400" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
+          </svg>
+          <div>
+            <p className="text-sm font-medium text-amber-200">
+              The scanner backend is unavailable
+            </p>
+            <p className="mt-1 text-xs text-amber-300/80">
+              Scans cannot complete right now. Please try again later.
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="flex-shrink-0 text-amber-400 hover:text-amber-300"
+          aria-label="Dismiss"
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -24,6 +24,7 @@ const config: Config = {
     '/lib/__tests__/wallet',
     '/lib/__tests__/schedule',
     '/lib/__tests__/httpClient',
+    '/lib/__tests__/apiHealth',
     '/components/WalletConnect\\.test\\.tsx',
   ],
   transform: {

--- a/lib/__tests__/apiHealth.test.ts
+++ b/lib/__tests__/apiHealth.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { checkApiHealth, getApiBaseUrl } from '../api'
+import { checkBackendReachability } from '../env'
+
+describe('getApiBaseUrl', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('process', { env: {} })
+  })
+
+  it('returns localhost when NEXT_PUBLIC_API_URL is unset', () => {
+    expect(getApiBaseUrl()).toBe('http://localhost:3001')
+  })
+
+  it('strips trailing slash from configured URL', () => {
+    vi.stubGlobal('process', { env: { NEXT_PUBLIC_API_URL: 'https://api.example.com/' } })
+    expect(getApiBaseUrl()).toBe('https://api.example.com')
+  })
+
+  it('returns URL as-is when no trailing slash', () => {
+    vi.stubGlobal('process', { env: { NEXT_PUBLIC_API_URL: 'https://api.example.com' } })
+    expect(getApiBaseUrl()).toBe('https://api.example.com')
+  })
+})
+
+describe('checkApiHealth', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('fetch', vi.fn())
+    vi.stubGlobal('process', { env: { NEXT_PUBLIC_API_URL: 'https://api.example.com' } })
+  })
+
+  it('returns true when /health responds 200', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+    expect(await checkApiHealth()).toBe(true)
+    expect(fetch).toHaveBeenCalledWith('https://api.example.com/health', expect.anything())
+  })
+
+  it('returns false when /health responds non-2xx', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false } as Response)
+    expect(await checkApiHealth()).toBe(false)
+  })
+
+  it('returns false when fetch throws', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('Network error'))
+    expect(await checkApiHealth()).toBe(false)
+  })
+})
+
+describe('checkBackendReachability', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('returns warning when NEXT_PUBLIC_API_URL is missing', async () => {
+    vi.stubGlobal('process', { env: {} })
+    const result = await checkBackendReachability()
+    expect(result).toContain('NEXT_PUBLIC_API_URL is not configured')
+  })
+
+  it('returns warning when NEXT_PUBLIC_API_URL is malformed', async () => {
+    vi.stubGlobal('process', { env: { NEXT_PUBLIC_API_URL: 'not-a-url' } })
+    const result = await checkBackendReachability()
+    expect(result).toContain('malformed')
+  })
+
+  it('returns warning when /health is unreachable', async () => {
+    vi.stubGlobal('process', { env: { NEXT_PUBLIC_API_URL: 'https://api.example.com' } })
+    vi.mocked(fetch).mockRejectedValue(new Error('Network error'))
+    const result = await checkBackendReachability()
+    expect(result).toBe('The scanner backend is unavailable.')
+  })
+
+  it('returns warning when /health returns non-2xx', async () => {
+    vi.stubGlobal('process', { env: { NEXT_PUBLIC_API_URL: 'https://api.example.com' } })
+    vi.mocked(fetch).mockResolvedValue({ ok: false, status: 500 } as Response)
+    const result = await checkBackendReachability()
+    expect(result).toContain('status 500')
+  })
+
+  it('returns null when backend is healthy', async () => {
+    vi.stubGlobal('process', { env: { NEXT_PUBLIC_API_URL: 'https://api.example.com' } })
+    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+    const result = await checkBackendReachability()
+    expect(result).toBeNull()
+  })
+})

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -9,6 +9,32 @@ export type { ScanQuota, ScanResult }
 const client = new SorobanGuardClient()
 
 /**
+ * Get the API base URL from the client (browser) environment.
+ */
+export function getApiBaseUrl(): string {
+  if (typeof window === 'undefined') {
+    return 'http://localhost:3001'
+  }
+  return (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001').replace(/\/$/, '')
+}
+
+/**
+ * Check whether the Soroban Guard API backend is reachable.
+ * @returns True if /health responds with 200 within 5 seconds
+ */
+export async function checkApiHealth(): Promise<boolean> {
+  try {
+    const baseUrl = getApiBaseUrl()
+    const res = await fetch(`${baseUrl}/health`, {
+      signal: AbortSignal.timeout(5000),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+/**
  * Submit source code to the Soroban Guard API for scanning.
  * @param source - Contract source code or identifier
  * @param network - Optional Stellar network to target

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -23,3 +23,35 @@ export function validateEnv(): void {
     )
   }
 }
+
+/**
+ * Client-side reachability check for the scanner backend.
+ * Returns a user-facing warning string if the backend appears unreachable,
+ * or null if it is healthy.
+ */
+export async function checkBackendReachability(): Promise<string | null> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL
+
+  if (!apiUrl) {
+    return 'NEXT_PUBLIC_API_URL is not configured. The scanner backend is unreachable.'
+  }
+
+  try {
+    new URL(apiUrl)
+  } catch {
+    return `NEXT_PUBLIC_API_URL is malformed: "${apiUrl}". The scanner backend is unreachable.`
+  }
+
+  try {
+    const res = await fetch(`${apiUrl.replace(/\/$/, '')}/health`, {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) {
+      return `The scanner backend responded with status ${res.status}.`
+    }
+  } catch {
+    return 'The scanner backend is unavailable.'
+  }
+
+  return null
+}


### PR DESCRIPTION
- Add checkApiHealth/checkBackendReachability to lib/api.ts and lib/env.ts
- Show ApiHealthBanner when backend is unreachable
- Surface friendly error on fetch failure in handleScan
- Document NEXT_PUBLIC_API_URL Vercel build-time requirement in .env.example and README
- Add unit tests for health/reachability helpers

## Description

<!-- What does this PR do? Link the relevant issue if applicable. -->

- closes #521 

## Checklist

- [x] TypeScript compiles with no errors (`npm run build`)
- [x] ESLint passes (`npm run lint`)
- [x] Tested in browser (Chrome + Firefox)
- [x] Mobile layout checked
- [x] No `console.log` left in code
- [x] Relevant docs updated
